### PR TITLE
Mutex in ClientID() method removed

### DIFF
--- a/centrifuge.go
+++ b/centrifuge.go
@@ -341,8 +341,6 @@ func (c *centrifuge) subscribed(channel string) bool {
 // ClientID returns client ID of this connection. It only available after connection
 // was established and authorized.
 func (c *centrifuge) ClientID() string {
-	c.mutex.RLock()
-	defer c.mutex.RUnlock()
 	return string(c.clientID)
 }
 


### PR DESCRIPTION
When server was shutted down(i.e. docker container stopped) and client starts to reconnect, this mutex stucks client forever. But it works normally when client connects for the first time. Is mutex is a necessery in this metod?
Debugging was made with client from examples(on windows 10 and ubuntu 18.04) and centrifuge server in docker.