### PR TITLE
Backwards incompatible API design fixes

### DIFF
--- a/examples/example.go
+++ b/examples/example.go
@@ -44,26 +44,29 @@ func main() {
 
 	url := "ws://localhost:8000/connection/websocket"
 
-	eventHandler := &eventHandler{}
-	events := centrifuge.NewEventHub()
-	events.OnConnect(eventHandler)
-	events.OnDisconnect(eventHandler)
-
-	c := centrifuge.New(url, events, centrifuge.DefaultConfig())
+	c := centrifuge.New(url, centrifuge.DefaultConfig())
 	defer c.Close()
+
+	eventHandler := &eventHandler{}
+	c.OnConnect(eventHandler)
+	c.OnDisconnect(eventHandler)
 
 	err := c.Connect()
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	subEvents := centrifuge.NewSubscriptionEventHub()
-	subEventHandler := &subEventHandler{}
-	subEvents.OnPublish(subEventHandler)
-	subEvents.OnJoin(subEventHandler)
-	subEvents.OnLeave(subEventHandler)
+	sub, err := c.NewSubscription("chat:index")
+	if err != nil {
+		log.Fatalln(err)
+	}
 
-	sub, err := c.Subscribe("chat:index", subEvents)
+	subEventHandler := &subEventHandler{}
+	sub.OnPublish(subEventHandler)
+	sub.OnJoin(subEventHandler)
+	sub.OnLeave(subEventHandler)
+
+	err = sub.Subscribe()
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/testsuite/main.go
+++ b/examples/testsuite/main.go
@@ -43,13 +43,13 @@ func testCustomHeader() {
 	config := centrifuge.DefaultConfig()
 	config.Header.Add("Authorization", "testsuite")
 
-	events := centrifuge.NewEventHub()
-	eventHandler := &eventHandler{}
-	events.OnConnect(eventHandler)
-	events.OnDisconnect(eventHandler)
-
-	c := centrifuge.New(url, events, config)
+	c := centrifuge.New(url, config)
 	defer c.Close()
+
+	eventHandler := &eventHandler{}
+	c.OnConnect(eventHandler)
+	c.OnDisconnect(eventHandler)
+
 	err := c.Connect()
 	if err != nil {
 		panic(err.Error())
@@ -59,14 +59,15 @@ func testCustomHeader() {
 func testJWTAuth() {
 	url := "ws://localhost:10001/connection/websocket"
 	config := centrifuge.DefaultConfig()
-	events := centrifuge.NewEventHub()
-	eventHandler := &eventHandler{}
-	events.OnConnect(eventHandler)
-	events.OnDisconnect(eventHandler)
 
-	c := centrifuge.New(url, events, config)
-	c.SetToken("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0c3VpdGVfand0IiwiZXhwIjoxNTM0NjY0MjE0fQ.pFyddmlMVYQWmed3dfzuHOViNew9DP2yHjzE20unFb4")
+	c := centrifuge.New(url, config)
+	c.SetToken("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0c3VpdGVfand0In0.hPmHsVqvtY88PvK4EmJlcdwNuKFuy3BGaF7dMaKdPlw")
 	defer c.Close()
+
+	eventHandler := &eventHandler{}
+	c.OnConnect(eventHandler)
+	c.OnDisconnect(eventHandler)
+
 	err := c.Connect()
 	if err != nil {
 		panic(err.Error())
@@ -76,18 +77,25 @@ func testJWTAuth() {
 func testSimpleSubscribe() {
 	url := "ws://localhost:10002/connection/websocket"
 	config := centrifuge.DefaultConfig()
-	events := centrifuge.NewEventHub()
-	eventHandler := &eventHandler{}
-	events.OnConnect(eventHandler)
-	events.OnDisconnect(eventHandler)
 
-	c := centrifuge.New(url, events, config)
+	c := centrifuge.New(url, config)
 	defer c.Close()
+
+	eventHandler := &eventHandler{}
+	c.OnConnect(eventHandler)
+	c.OnDisconnect(eventHandler)
+
 	err := c.Connect()
 	if err != nil {
 		panic(err.Error())
 	}
-	c.Subscribe("testsuite", nil)
+
+	sub, err := c.NewSubscription("testsuite")
+	if err != nil {
+		panic(err.Error())
+	}
+
+	sub.Subscribe()
 	time.Sleep(time.Second)
 }
 
@@ -97,13 +105,14 @@ func testReceiveRPCReceiveMessage(protobuf bool) {
 		url = "ws://localhost:10004/connection/websocket?format=protobuf"
 	}
 	config := centrifuge.DefaultConfig()
-	events := centrifuge.NewEventHub()
-	eventHandler := &eventHandler{}
-	events.OnConnect(eventHandler)
-	events.OnDisconnect(eventHandler)
 
-	c := centrifuge.New(url, events, config)
+	c := centrifuge.New(url, config)
 	defer c.Close()
+
+	eventHandler := &eventHandler{}
+	c.OnConnect(eventHandler)
+	c.OnDisconnect(eventHandler)
+
 	err := c.Connect()
 	if err != nil {
 		panic(err)

--- a/subscription.go
+++ b/subscription.go
@@ -81,39 +81,39 @@ type SubscriptionEventHub struct {
 	onSubscribeError   SubscribeErrorHandler
 }
 
-// NewSubscriptionEventHub initializes new SubscriptionEventHub.
-func NewSubscriptionEventHub() *SubscriptionEventHub {
+// newSubscriptionEventHub initializes new SubscriptionEventHub.
+func newSubscriptionEventHub() *SubscriptionEventHub {
 	return &SubscriptionEventHub{}
 }
 
 // OnPublish allows to set PublishHandler to SubEventHandler.
-func (h *SubscriptionEventHub) OnPublish(handler PublishHandler) {
-	h.onPublish = handler
+func (s *Subscription) OnPublish(handler PublishHandler) {
+	s.events.onPublish = handler
 }
 
 // OnJoin allows to set JoinHandler to SubEventHandler.
-func (h *SubscriptionEventHub) OnJoin(handler JoinHandler) {
-	h.onJoin = handler
+func (s *Subscription) OnJoin(handler JoinHandler) {
+	s.events.onJoin = handler
 }
 
 // OnLeave allows to set LeaveHandler to SubEventHandler.
-func (h *SubscriptionEventHub) OnLeave(handler LeaveHandler) {
-	h.onLeave = handler
+func (s *Subscription) OnLeave(handler LeaveHandler) {
+	s.events.onLeave = handler
 }
 
 // OnUnsubscribe allows to set UnsubscribeHandler to SubEventHandler.
-func (h *SubscriptionEventHub) OnUnsubscribe(handler UnsubscribeHandler) {
-	h.onUnsubscribe = handler
+func (s *Subscription) OnUnsubscribe(handler UnsubscribeHandler) {
+	s.events.onUnsubscribe = handler
 }
 
 // OnSubscribeSuccess allows to set SubscribeSuccessHandler to SubEventHandler.
-func (h *SubscriptionEventHub) OnSubscribeSuccess(handler SubscribeSuccessHandler) {
-	h.onSubscribeSuccess = handler
+func (s *Subscription) OnSubscribeSuccess(handler SubscribeSuccessHandler) {
+	s.events.onSubscribeSuccess = handler
 }
 
 // OnSubscribeError allows to set SubscribeErrorHandler to SubEventHandler.
-func (h *SubscriptionEventHub) OnSubscribeError(handler SubscribeErrorHandler) {
-	h.onSubscribeError = handler
+func (s *Subscription) OnSubscribeError(handler SubscribeErrorHandler) {
+	s.events.onSubscribeError = handler
 }
 
 // Describe different states of Sub.
@@ -145,11 +145,11 @@ type Subscription struct {
 	subFutures      []chan error
 }
 
-func (c *Client) newSubscription(channel string, events *SubscriptionEventHub) *Subscription {
+func (c *Client) newSubscription(channel string) *Subscription {
 	s := &Subscription{
 		centrifuge:      c,
 		channel:         channel,
-		events:          events,
+		events:          newSubscriptionEventHub(),
 		subFutures:      make([]chan error, 0),
 		needResubscribe: true,
 	}


### PR DESCRIPTION
The problem originally found in https://github.com/centrifugal/centrifuge-mobile/issues/16 - we can't properly pass client and subscription objects to callback handlers. This worked with this library but I think we should try to keep API in sync with centrifuge-mobile.