### PR TITLE
Fix private subscription error handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: go
+services:
+- docker
+before_install:
+- docker pull centrifugo/centrifugo
+- docker run -d -p 8000:8000 centrifugo/centrifugo centrifugo --client_insecure
 install:
 - go get -u github.com/golang/dep/cmd/dep
 - dep ensure

--- a/client.go
+++ b/client.go
@@ -288,7 +288,7 @@ func (c *Client) handleDisconnect(d *disconnect) {
 
 	go func() {
 		c.mutex.Lock()
-		duration, err := c.reconnectStrategy.waitBeforeNextAttempt(c.reconnectAttempts)
+		duration, err := c.reconnectStrategy.timeBeforeNextAttempt(c.reconnectAttempts)
 		c.mutex.Unlock()
 		if err != nil {
 			c.handleError(err)
@@ -312,7 +312,7 @@ func (c *Client) handleDisconnect(d *disconnect) {
 }
 
 type reconnectStrategy interface {
-	waitBeforeNextAttempt(attempt int) (time.Duration, error)
+	timeBeforeNextAttempt(attempt int) (time.Duration, error)
 }
 
 type backoffReconnect struct {
@@ -336,7 +336,7 @@ var defaultBackoffReconnect = &backoffReconnect{
 	Jitter:          true,
 }
 
-func (r *backoffReconnect) waitBeforeNextAttempt(attempt int) (time.Duration, error) {
+func (r *backoffReconnect) timeBeforeNextAttempt(attempt int) (time.Duration, error) {
 	b := &backoff.Backoff{
 		Min:    time.Duration(r.MinMilliseconds) * time.Millisecond,
 		Max:    time.Duration(r.MaxMilliseconds) * time.Millisecond,

--- a/client.go
+++ b/client.go
@@ -46,6 +46,7 @@ type Client struct {
 	receive           chan []byte
 	closeCh           chan struct{}
 	reconnect         bool
+	reconnectAttempts int
 	reconnectStrategy reconnectStrategy
 	events            *EventHub
 	paramsEncoder     proto.ParamsEncoder
@@ -221,10 +222,12 @@ func (c *Client) handleDisconnect(d *disconnect) {
 	}
 
 	c.mutex.Lock()
-	if c.status == DISCONNECTED || c.status == CLOSED || c.status == RECONNECTING {
+	if c.status == DISCONNECTED || c.status == CLOSED {
 		c.mutex.Unlock()
 		return
 	}
+
+	isReconnecting := c.status == RECONNECTING
 
 	c.reconnect = d.Reconnect
 
@@ -275,7 +278,7 @@ func (c *Client) handleDisconnect(d *disconnect) {
 		handler = c.events.onDisconnect
 	}
 
-	if handler != nil {
+	if handler != nil && !isReconnecting {
 		handler.OnDisconnect(c, DisconnectEvent{Reason: d.Reason, Reconnect: reconnect})
 	}
 
@@ -284,16 +287,32 @@ func (c *Client) handleDisconnect(d *disconnect) {
 	}
 
 	go func() {
-		err := c.reconnectStrategy.reconnect(c)
+		c.mutex.Lock()
+		duration, err := c.reconnectStrategy.waitBeforeNextAttempt(c.reconnectAttempts)
+		c.mutex.Unlock()
 		if err != nil {
 			c.handleError(err)
-			c.Close()
+			return
+		}
+		select {
+		case <-time.After(duration):
+			c.mutex.Lock()
+			c.reconnectAttempts++
+			if !c.reconnect {
+				c.mutex.Unlock()
+				return
+			}
+			c.mutex.Unlock()
+			err := c.connectFromScratch(true)
+			if err != nil {
+				c.handleError(err)
+			}
 		}
 	}()
 }
 
 type reconnectStrategy interface {
-	reconnect(c *Client) error
+	waitBeforeNextAttempt(attempt int) (time.Duration, error)
 }
 
 type backoffReconnect struct {
@@ -317,55 +336,17 @@ var defaultBackoffReconnect = &backoffReconnect{
 	Jitter:          true,
 }
 
-func (r *backoffReconnect) reconnect(c *Client) error {
+func (r *backoffReconnect) waitBeforeNextAttempt(attempt int) (time.Duration, error) {
 	b := &backoff.Backoff{
 		Min:    time.Duration(r.MinMilliseconds) * time.Millisecond,
 		Max:    time.Duration(r.MaxMilliseconds) * time.Millisecond,
 		Factor: r.Factor,
 		Jitter: r.Jitter,
 	}
-	reconnects := 0
-
-	for {
-		if r.NumReconnect > 0 && reconnects >= r.NumReconnect {
-			break
-		}
-		time.Sleep(b.Duration())
-
-		reconnects++
-		c.mutex.RLock()
-		reconnect := c.reconnect
-		c.mutex.RUnlock()
-		if !reconnect {
-			return nil
-		}
-		err := c.doReconnect()
-		if err != nil {
-			continue
-		}
-
-		// successfully reconnected
-		return nil
+	if r.NumReconnect > 0 && attempt >= r.NumReconnect {
+		return 0, ErrReconnectFailed
 	}
-	return ErrReconnectFailed
-}
-
-func (c *Client) doReconnect() error {
-	err := c.connect(true)
-	if err != nil {
-		c.close()
-		return err
-	}
-
-	err = c.resubscribe()
-	if err != nil {
-		// we need just to close the connection and outgoing requests here
-		// but preserve all subscriptions.
-		c.close()
-		return err
-	}
-
-	return nil
+	return b.ForAttempt(float64(attempt)), nil
 }
 
 func (c *Client) pinger(closeCh chan struct{}) {
@@ -511,8 +492,7 @@ func (c *Client) handlePush(msg proto.Push) error {
 	return nil
 }
 
-// Connect dials to server and sends connect message.
-func (c *Client) Connect() error {
+func (c *Client) connectFromScratch(isReconnect bool) error {
 	c.mutex.Lock()
 	if c.status == CONNECTED || c.status == CONNECTING || c.status == RECONNECTING {
 		c.mutex.Unlock()
@@ -522,11 +502,15 @@ func (c *Client) Connect() error {
 		c.mutex.Unlock()
 		return ErrClientClosed
 	}
-	c.status = CONNECTING
+	if isReconnect {
+		c.status = RECONNECTING
+	} else {
+		c.status = CONNECTING
+	}
 	c.reconnect = true
 	c.mutex.Unlock()
 
-	err := c.connect(false)
+	err := c.connect(isReconnect)
 	if err != nil {
 		if c.transport == nil {
 			c.handleError(err)
@@ -538,11 +522,22 @@ func (c *Client) Connect() error {
 	if err != nil {
 		// we need just to close the connection and outgoing requests here
 		// but preserve all subscriptions.
+		c.handleError(err)
 		c.close()
 		return nil
 	}
 
+	// Looks like we successfully reconnected so can reset reconnect attempts.
+	c.mutex.Lock()
+	c.reconnectAttempts = 0
+	c.mutex.Unlock()
+
 	return nil
+}
+
+// Connect dials to server and sends connect message.
+func (c *Client) Connect() error {
+	return c.connectFromScratch(false)
 }
 
 func (c *Client) connect(isReconnect bool) error {
@@ -558,7 +553,6 @@ func (c *Client) connect(isReconnect bool) error {
 	}
 	c.closeCh = make(chan struct{})
 	c.mutex.Unlock()
-
 	wsConfig := websocketConfig{
 		TLSConfig:         c.config.TLSConfig,
 		HandshakeTimeout:  c.config.HandshakeTimeout,
@@ -1161,7 +1155,13 @@ func (c *Client) send(cmd *proto.Command) error {
 	case <-c.closeCh:
 		return ErrClientDisconnected
 	default:
-		err := c.transport.Write(cmd, c.config.WriteTimeout)
+		c.mutex.Lock()
+		transport := c.transport
+		c.mutex.Unlock()
+		if transport == nil {
+			return ErrClientDisconnected
+		}
+		err := transport.Write(cmd, c.config.WriteTimeout)
 		if err != nil {
 			go c.handleDisconnect(&disconnect{Reason: "write error", Reconnect: true})
 			return err

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,257 @@
+package centrifuge
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"time"
+)
+
+type testEventHandler struct {
+	onConnect    func(*Client, ConnectEvent)
+	onDisconnect func(*Client, DisconnectEvent)
+}
+
+func (h *testEventHandler) OnConnect(c *Client, e ConnectEvent) {
+	if h.onConnect != nil {
+		h.onConnect(c, e)
+	}
+}
+
+func (h *testEventHandler) OnDisconnect(c *Client, e DisconnectEvent) {
+	if h.onDisconnect != nil {
+		h.onDisconnect(c, e)
+	}
+}
+
+type testSubscriptionHandler struct {
+	onSubscribeSuccess func(*Subscription, SubscribeSuccessEvent)
+	onSubscribeError   func(*Subscription, SubscribeErrorEvent)
+	onPublish          func(*Subscription, PublishEvent)
+}
+
+func (h *testSubscriptionHandler) OnSubscribeSuccess(c *Subscription, e SubscribeSuccessEvent) {
+	if h.onSubscribeSuccess != nil {
+		h.onSubscribeSuccess(c, e)
+	}
+}
+
+func (h *testSubscriptionHandler) OnSubscribeError(c *Subscription, e SubscribeErrorEvent) {
+	if h.onSubscribeError != nil {
+		h.onSubscribeError(c, e)
+	}
+}
+
+func (h *testSubscriptionHandler) OnPublish(c *Subscription, e PublishEvent) {
+	if h.onPublish != nil {
+		h.onPublish(c, e)
+	}
+}
+
+func TestConnectWrongAddress(t *testing.T) {
+	client := New("ws://localhost:9000/connection/websocket", DefaultConfig())
+	defer client.Close()
+	doneCh := make(chan error, 1)
+	handler := &testEventHandler{
+		onDisconnect: func(c *Client, e DisconnectEvent) {
+			if e.Reconnect != true {
+				doneCh <- fmt.Errorf("wrong reconnect value")
+				return
+			}
+			close(doneCh)
+		},
+	}
+	client.OnDisconnect(handler)
+	client.Connect()
+	select {
+	case err := <-doneCh:
+		if err != nil {
+			t.Errorf("finish with error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Errorf("expecting disconnect due to malformed address")
+	}
+}
+
+func TestSuccessfulConnect(t *testing.T) {
+	client := New("ws://localhost:8000/connection/websocket?format=protobuf", DefaultConfig())
+	defer client.Close()
+	doneCh := make(chan error, 1)
+	handler := &testEventHandler{
+		onConnect: func(c *Client, e ConnectEvent) {
+			if e.ClientID == "" {
+				doneCh <- fmt.Errorf("wrong client ID value")
+				return
+			}
+			close(doneCh)
+		},
+	}
+	client.OnConnect(handler)
+	client.Connect()
+	select {
+	case err := <-doneCh:
+		if err != nil {
+			t.Errorf("finish with error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Errorf("expecting successful connect")
+	}
+}
+
+func TestDisconnect(t *testing.T) {
+	client := New("ws://localhost:8000/connection/websocket?format=protobuf", DefaultConfig())
+	defer client.Close()
+	connectDoneCh := make(chan error, 1)
+	disconnectDoneCh := make(chan error, 1)
+	handler := &testEventHandler{
+		onConnect: func(c *Client, e ConnectEvent) {
+			close(connectDoneCh)
+		},
+		onDisconnect: func(c *Client, e DisconnectEvent) {
+			if e.Reconnect != false {
+				disconnectDoneCh <- fmt.Errorf("wrong reconnect value")
+				return
+			}
+			close(disconnectDoneCh)
+		},
+	}
+	client.OnConnect(handler)
+	client.OnDisconnect(handler)
+	client.Connect()
+	select {
+	case err := <-connectDoneCh:
+		if err != nil {
+			t.Errorf("finish with error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Errorf("expecting successful connect")
+	}
+	client.Disconnect()
+	select {
+	case err := <-disconnectDoneCh:
+		if err != nil {
+			t.Errorf("finish with error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Errorf("expecting successful disconnect")
+	}
+}
+
+func TestPublishProtobuf(t *testing.T) {
+	client := New("ws://localhost:8000/connection/websocket?format=protobuf", DefaultConfig())
+	defer client.Close()
+	client.Connect()
+	err := client.Publish("test", []byte("boom"))
+	if err != nil {
+		t.Errorf("error publish: %v", err)
+	}
+}
+
+func TestPublishJSON(t *testing.T) {
+	client := New("ws://localhost:8000/connection/websocket?format=protobuf", DefaultConfig())
+	defer client.Close()
+	client.Connect()
+	err := client.Publish("test", []byte("{}"))
+	if err != nil {
+		t.Errorf("error publish: %v", err)
+	}
+}
+
+func TestPublishInvalidJSON(t *testing.T) {
+	client := New("ws://localhost:8000/connection/websocket", DefaultConfig())
+	defer client.Close()
+	client.Connect()
+	err := client.Publish("test", []byte("boom"))
+	if err == nil {
+		t.Errorf("error expected on publish invalid JSON")
+	}
+}
+
+func TestSubscribeSuccess(t *testing.T) {
+	doneCh := make(chan error, 1)
+	client := New("ws://localhost:8000/connection/websocket", DefaultConfig())
+	defer client.Close()
+	client.Connect()
+	sub, err := client.NewSubscription("test")
+	if err != nil {
+		t.Errorf("error on new subscription: %v", err)
+	}
+	sub.OnSubscribeSuccess(&testSubscriptionHandler{
+		onSubscribeSuccess: func(c *Subscription, e SubscribeSuccessEvent) {
+			close(doneCh)
+		},
+	})
+	sub.Subscribe()
+	select {
+	case err := <-doneCh:
+		if err != nil {
+			t.Errorf("finish with error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Errorf("expecting successful subscribe")
+	}
+}
+
+func TestSubscribeError(t *testing.T) {
+	doneCh := make(chan error, 1)
+	client := New("ws://localhost:8000/connection/websocket", DefaultConfig())
+	defer client.Close()
+	client.Connect()
+	sub, err := client.NewSubscription("test:test")
+	if err != nil {
+		t.Errorf("error on new subscription: %v", err)
+	}
+	sub.OnSubscribeError(&testSubscriptionHandler{
+		onSubscribeError: func(c *Subscription, e SubscribeErrorEvent) {
+			// Due to unknown namespace.
+			close(doneCh)
+		},
+	})
+	sub.Subscribe()
+	select {
+	case err := <-doneCh:
+		if err != nil {
+			t.Errorf("finish with error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Errorf("expecting subscribe error")
+	}
+}
+
+func TestHandlePublish(t *testing.T) {
+	doneCh := make(chan error, 1)
+	client := New("ws://localhost:8000/connection/websocket", DefaultConfig())
+	defer client.Close()
+	client.Connect()
+	sub, err := client.NewSubscription("test")
+	if err != nil {
+		t.Errorf("error on new subscription: %v", err)
+	}
+	handler := &testSubscriptionHandler{
+		onSubscribeSuccess: func(c *Subscription, e SubscribeSuccessEvent) {
+			client.Publish("test", []byte(`{}`))
+		},
+		onPublish: func(c *Subscription, e PublishEvent) {
+			if !bytes.Equal(e.Data, []byte(`{}`)) {
+				doneCh <- fmt.Errorf("wrong publication data")
+				return
+			}
+			if e.Info == nil {
+				doneCh <- fmt.Errorf("expecting non nil publication info")
+				return
+			}
+			close(doneCh)
+		},
+	}
+	sub.OnSubscribeSuccess(handler)
+	sub.OnPublish(handler)
+	sub.Subscribe()
+	select {
+	case err := <-doneCh:
+		if err != nil {
+			t.Errorf("finish with error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Errorf("expecting publication received over subscription")
+	}
+}

--- a/subscription.go
+++ b/subscription.go
@@ -1,6 +1,7 @@
 package centrifuge
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -415,7 +416,10 @@ func (s *Subscription) resubscribe(isResubscribe bool) error {
 
 	token, err := s.centrifuge.privateSign(s.channel)
 	if err != nil {
-		return err
+		s.mu.Lock()
+		s.status = UNSUBSCRIBED
+		s.mu.Unlock()
+		return fmt.Errorf("error subscribing on channel %s: %v", s.channel, err)
 	}
 
 	s.mu.Lock()


### PR DESCRIPTION
In order to solve #22

When private subscription handler returns an error we now properly disconnect from Centrifugo and try to reconnect with backoff interval until we successfully connected and successfully resubscribed.