### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/internal/proto/marshal.go
+++ b/internal/proto/marshal.go
@@ -119,7 +119,7 @@ func (e *ProtobufPushEncoder) EncodePublication(message *Publication) ([]byte, e
 	return message.Marshal()
 }
 
-// EncodePush ...
+// EncodeMessage ...
 func (e *ProtobufPushEncoder) EncodeMessage(message *Message) ([]byte, error) {
 	return message.Marshal()
 }


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?