### PR TITLE
NamedRPC method added

### DIFF
--- a/client.go
+++ b/client.go
@@ -203,31 +203,7 @@ func (c *Client) Send(data []byte) error {
 // RPC allows to make RPC – send data to server ant wait for response.
 // RPC handler must be registered on server.
 func (c *Client) RPC(data []byte) ([]byte, error) {
-	cmd := &protocol.Command{
-		ID:     c.nextMsgID(),
-		Method: protocol.MethodTypeRPC,
-	}
-	params := &protocol.RPCRequest{
-		Data: data,
-	}
-	paramsData, err := c.paramsEncoder.Encode(params)
-	if err != nil {
-		return nil, fmt.Errorf("encode error: %v", err)
-	}
-	cmd.Params = paramsData
-	r, err := c.sendSync(cmd)
-	if err != nil {
-		return nil, err
-	}
-	if r.Error != nil {
-		return nil, r.Error
-	}
-	var res protocol.RPCResult
-	err = c.resultDecoder.Decode(r.Result, &res)
-	if err != nil {
-		return nil, err
-	}
-	return res.Data, nil
+	return c.NamedRPC("", data)
 }
 
 // NamedRPC allows to make RPC – send data to server ant wait for response.

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -2,6 +2,8 @@ github.com/centrifugal/protocol v0.3.0 h1:4W9TKybntVlAfMkf54vtmbrZ9dcLHynqiw93vf
 github.com/centrifugal/protocol v0.3.0/go.mod h1:2YbBCaDwQHl37ErRdMrKSj18X2yVvpkQYtSX6aVbe5A=
 github.com/centrifugal/protocol v0.3.1 h1:6/+seAUMDF8Z6QuI/vCtiKGJZw8qatdOXal3DALeU00=
 github.com/centrifugal/protocol v0.3.1/go.mod h1:2YbBCaDwQHl37ErRdMrKSj18X2yVvpkQYtSX6aVbe5A=
+github.com/centrifugal/protocol v0.3.3 h1:GCNee3RFsjQu6SyKBX0Ir7ByUrp+Gw0MU/PsIc2CM2s=
+github.com/centrifugal/protocol v0.3.3/go.mod h1:2YbBCaDwQHl37ErRdMrKSj18X2yVvpkQYtSX6aVbe5A=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
@@ -10,6 +12,8 @@ github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0U
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/jpillora/backoff v0.0.0-20170918002102-8eab2debe79d h1:ix3WmphUvN0GDd0DO9MH0v6/5xTv+Xm1bPN+1UJn58k=
 github.com/jpillora/backoff v0.0.0-20170918002102-8eab2debe79d/go.mod h1:2iMrUgbbvHEiQClaW2NsSzMyGHqN+rDFqY705q49KG0=
+github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
+github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/examples/testsuite/main.go
+++ b/examples/testsuite/main.go
@@ -127,12 +127,42 @@ func testReceiveRPCReceiveMessage(protobuf bool) {
 	}
 }
 
+func testReceiveNamedRPCReceiveMessage(protobuf bool) {
+	url := "ws://localhost:10005/connection/websocket"
+	if protobuf {
+		url = "ws://localhost:10006/connection/websocket?format=protobuf"
+	}
+	config := centrifuge.DefaultConfig()
+
+	c := centrifuge.New(url, config)
+	defer c.Close()
+
+	eventHandler := &eventHandler{}
+	c.OnConnect(eventHandler)
+	c.OnDisconnect(eventHandler)
+
+	err := c.Connect()
+	if err != nil {
+		panic(err)
+	}
+	data, err := c.NamedRPC("test", []byte("{}"))
+	if err != nil {
+		panic(err)
+	}
+	err = c.Send(data)
+	if err != nil {
+		panic(err)
+	}
+}
+
 func main() {
 	go testCustomHeader()
 	go testJWTAuth()
 	go testSimpleSubscribe()
 	go testReceiveRPCReceiveMessage(false)
 	go testReceiveRPCReceiveMessage(true)
+	go testReceiveNamedRPCReceiveMessage(false)
+	go testReceiveNamedRPCReceiveMessage(true)
 
 	select {}
 }

--- a/examples/testsuite/main.go
+++ b/examples/testsuite/main.go
@@ -127,42 +127,12 @@ func testReceiveRPCReceiveMessage(protobuf bool) {
 	}
 }
 
-func testReceiveNamedRPCReceiveMessage(protobuf bool) {
-	url := "ws://localhost:10005/connection/websocket"
-	if protobuf {
-		url = "ws://localhost:10006/connection/websocket?format=protobuf"
-	}
-	config := centrifuge.DefaultConfig()
-
-	c := centrifuge.New(url, config)
-	defer c.Close()
-
-	eventHandler := &eventHandler{}
-	c.OnConnect(eventHandler)
-	c.OnDisconnect(eventHandler)
-
-	err := c.Connect()
-	if err != nil {
-		panic(err)
-	}
-	data, err := c.NamedRPC("test", []byte("{}"))
-	if err != nil {
-		panic(err)
-	}
-	err = c.Send(data)
-	if err != nil {
-		panic(err)
-	}
-}
-
 func main() {
 	go testCustomHeader()
 	go testJWTAuth()
 	go testSimpleSubscribe()
 	go testReceiveRPCReceiveMessage(false)
 	go testReceiveRPCReceiveMessage(true)
-	go testReceiveNamedRPCReceiveMessage(false)
-	go testReceiveNamedRPCReceiveMessage(true)
 
 	select {}
 }


### PR DESCRIPTION
Current library does not provide any ability to send `Method` field. To prevent API breaking I add new method.

Most possibly this version should replace `RPC()` in future releases.