### PR TITLE
Fix private channel resubscribe deadlock

### DIFF
--- a/subscription.go
+++ b/subscription.go
@@ -316,7 +316,7 @@ func (s *Subscription) Subscribe() error {
 	if !s.centrifuge.connected() {
 		return nil
 	}
-	return s.resubscribe(false)
+	return s.resubscribe(false, s.centrifuge.clientID())
 }
 
 func (s *Subscription) triggerOnUnsubscribe(needResubscribe bool, needRecover bool) {
@@ -435,7 +435,7 @@ func (s *Subscription) handleUnsub(m protocol.Unsub) {
 	}
 }
 
-func (s *Subscription) resubscribe(isResubscribe bool) error {
+func (s *Subscription) resubscribe(isResubscribe bool, clientID string) error {
 	s.mu.Lock()
 	if s.status == SUBSCRIBED || s.status == SUBSCRIBING {
 		s.mu.Unlock()
@@ -450,7 +450,7 @@ func (s *Subscription) resubscribe(isResubscribe bool) error {
 	s.status = SUBSCRIBING
 	s.mu.Unlock()
 
-	token, err := s.centrifuge.privateSign(s.channel)
+	token, err := s.centrifuge.privateSign(s.channel, clientID)
 	if err != nil {
 		s.mu.Lock()
 		s.status = UNSUBSCRIBED


### PR DESCRIPTION
Fixes deadlock in situation when client resubscribes and tries to get channel private signature.

```
#	0x1043386	sync.runtime_SemacquireMutex+0x46						/usr/local/Cellar/go/1.13/libexec/src/runtime/sema.go:71
#	0x2f819b1	sync.(*RWMutex).RLock+0xc1							/usr/local/Cellar/go/1.13/libexec/src/sync/rwmutex.go:50
#	0x2f81919	github.com/centrifugal/centrifuge-go.(*Client).clientID+0x29			/go/pkg/mod/github.com/centrifugal/centrifuge-go@v0.6.1/client.go:189
#	0x2f866ec	github.com/centrifugal/centrifuge-go.(*Client).privateSign+0x7c			/go/pkg/mod/github.com/centrifugal/centrifuge-go@v0.6.1/client.go:1133
#	0x2f8ae7b	github.com/centrifugal/centrifuge-go.(*Subscription).resubscribe+0xdb		/go/pkg/mod/github.com/centrifugal/centrifuge-go@v0.6.1/subscription.go:453
#	0x2f85799	github.com/centrifugal/centrifuge-go.(*Client).resubscribe+0xa9			/go/pkg/mod/github.com/centrifugal/centrifuge-go@v0.6.1/client.go:918
#	0x2f8e1d5	github.com/centrifugal/centrifuge-go.(*Client).connectFromScratch.func1+0x865	/go/pkg/mod/github.com/centrifugal/centrifuge-go@v0.6.1/client.go:895
#	0x2f8eb33	github.com/centrifugal/centrifuge-go.(*Client).sendConnect.func1+0x1c3		/go/pkg/mod/github.com/centrifugal/centrifuge-go@v0.6.1/client.go:1123
#	0x2f835f6	github.com/centrifugal/centrifuge-go.(*Client).handle+0x136			/go/pkg/mod/github.com/centrifugal/centrifuge-go@v0.6.1/client.go:495
#	0x2f83374	github.com/centrifugal/centrifuge-go.(*Client).readOnce+0x94			/go/pkg/mod/github.com/centrifugal/centrifuge-go@v0.6.1/client.go:467
#	0x2f83488	github.com/centrifugal/centrifuge-go.(*Client).reader+0x78			/go/pkg/mod/github.com/centrifugal/centrifuge-go@v0.6.1/client.go:477
```