### PR TITLE
Remove subscription from client map on unsubscribe

### DIFF
--- a/client.go
+++ b/client.go
@@ -1507,6 +1507,9 @@ func (c *Client) unsubscribe(channel string, fn func(UnsubscribeResult, error)) 
 		return
 	}
 	c.sendUnsubscribe(channel, fn)
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	delete(c.subs, channel)
 }
 
 func (c *Client) sendUnsubscribe(channel string, fn func(UnsubscribeResult, error)) {

--- a/client.go
+++ b/client.go
@@ -1516,8 +1516,8 @@ func (c *Client) storeSubscription(s *Subscription) {
 	if c.subscribed(s.channel) {
 		return
 	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	c.subs[s.channel] = s
 }
 

--- a/client.go
+++ b/client.go
@@ -1512,6 +1512,15 @@ func (c *Client) unsubscribe(channel string, fn func(UnsubscribeResult, error)) 
 	delete(c.subs, channel)
 }
 
+func (c *Client) storeSubscription(s *Subscription) {
+	if c.subscribed(s.channel) {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.subs[s.channel] = s
+}
+
 func (c *Client) sendUnsubscribe(channel string, fn func(UnsubscribeResult, error)) {
 	params := &protocol.UnsubscribeRequest{
 		Channel: channel,

--- a/client.go
+++ b/client.go
@@ -1507,18 +1507,12 @@ func (c *Client) unsubscribe(channel string, fn func(UnsubscribeResult, error)) 
 		return
 	}
 	c.sendUnsubscribe(channel, fn)
+}
+
+func (c *Client) removeSubscription(channel string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	delete(c.subs, channel)
-}
-
-func (c *Client) storeSubscription(s *Subscription) {
-	if c.subscribed(s.channel) {
-		return
-	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.subs[s.channel] = s
 }
 
 func (c *Client) sendUnsubscribe(channel string, fn func(UnsubscribeResult, error)) {

--- a/client.go
+++ b/client.go
@@ -1507,8 +1507,8 @@ func (c *Client) unsubscribe(channel string, fn func(UnsubscribeResult, error)) 
 		return
 	}
 	c.sendUnsubscribe(channel, fn)
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	delete(c.subs, channel)
 }
 
@@ -1516,8 +1516,8 @@ func (c *Client) storeSubscription(s *Subscription) {
 	if c.subscribed(s.channel) {
 		return
 	}
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.subs[s.channel] = s
 }
 

--- a/errors.go
+++ b/errors.go
@@ -18,4 +18,7 @@ var (
 	// that server does not allow subscribing to the same channel twice for
 	// the same connection.
 	ErrDuplicateSubscription = errors.New("duplicate subscription")
+	// ErrSubscribeClosed returned if subscription was closed
+	// for subscribe to this channel should use Client's NewSubscription
+	ErrSubscribeClosed = errors.New("subscribe is closed")
 )

--- a/errors.go
+++ b/errors.go
@@ -20,5 +20,5 @@ var (
 	ErrDuplicateSubscription = errors.New("duplicate subscription")
 	// ErrSubscribeClosed returned if subscription was closed
 	// for subscribe to this channel should use Client's NewSubscription
-	ErrSubscribeClosed = errors.New("subscribe is closed")
+	ErrSubscriptionClosed = errors.New("subscription is closed")
 )

--- a/subscription.go
+++ b/subscription.go
@@ -485,6 +485,7 @@ func (s *Subscription) resubscribe(isResubscribe bool, clientID string) error {
 		s.subscribeSuccess(isRecover, res)
 	})
 	s.mu.Unlock()
+	s.centrifuge.storeSubscription(s)
 	return err
 }
 

--- a/subscription.go
+++ b/subscription.go
@@ -313,14 +313,11 @@ func (s *Subscription) Subscribe() error {
 	s.mu.Lock()
 	s.needResubscribe = true
 	s.mu.Unlock()
+	s.centrifuge.storeSubscription(s)
 	if !s.centrifuge.connected() {
 		return nil
 	}
-	err := s.resubscribe(false, s.centrifuge.clientID())
-	if err != nil {
-		s.centrifuge.storeSubscription(s)
-	}
-	return err
+	return s.resubscribe(false, s.centrifuge.clientID())
 }
 
 func (s *Subscription) triggerOnUnsubscribe(needResubscribe bool, needRecover bool) {

--- a/subscription.go
+++ b/subscription.go
@@ -316,7 +316,11 @@ func (s *Subscription) Subscribe() error {
 	if !s.centrifuge.connected() {
 		return nil
 	}
-	return s.resubscribe(false, s.centrifuge.clientID())
+	err := s.resubscribe(false, s.centrifuge.clientID())
+	if err != nil {
+		s.centrifuge.storeSubscription(s)
+	}
+	return err
 }
 
 func (s *Subscription) triggerOnUnsubscribe(needResubscribe bool, needRecover bool) {
@@ -485,7 +489,6 @@ func (s *Subscription) resubscribe(isResubscribe bool, clientID string) error {
 		s.subscribeSuccess(isRecover, res)
 	})
 	s.mu.Unlock()
-	s.centrifuge.storeSubscription(s)
 	return err
 }
 

--- a/subscription.go
+++ b/subscription.go
@@ -318,7 +318,7 @@ func (s *Subscription) Close() {
 // Subscribe allows to subscribe again after unsubscribing.
 func (s *Subscription) Subscribe() error {
 	if s.status == SUBCLOSED {
-		return ErrSubscribeClosed
+		return ErrSubscriptionClosed
 	}
 	s.mu.Lock()
 	s.needResubscribe = true

--- a/subscription.go
+++ b/subscription.go
@@ -192,6 +192,13 @@ func (s *Subscription) removeSubFuture(id uint64) {
 
 // Publish allows to publish data to channel.
 func (s *Subscription) Publish(data []byte) (PublishResult, error) {
+	s.mu.Lock()
+	if s.status == SUBCLOSED {
+		s.mu.Unlock()
+		return PublishResult{}, ErrSubscriptionClosed
+	}
+	s.mu.Unlock()
+
 	resCh := make(chan PublishResult, 1)
 	errCh := make(chan error, 1)
 	s.publish(data, func(result PublishResult, err error) {
@@ -203,6 +210,13 @@ func (s *Subscription) Publish(data []byte) (PublishResult, error) {
 
 // History allows to extract channel history.
 func (s *Subscription) History() (HistoryResult, error) {
+	s.mu.Lock()
+	if s.status == SUBCLOSED {
+		s.mu.Unlock()
+		return HistoryResult{}, ErrSubscriptionClosed
+	}
+	s.mu.Unlock()
+
 	resCh := make(chan HistoryResult, 1)
 	errCh := make(chan error, 1)
 	s.history(func(result HistoryResult, err error) {
@@ -214,6 +228,13 @@ func (s *Subscription) History() (HistoryResult, error) {
 
 // Presence allows to extract channel history.
 func (s *Subscription) Presence() (PresenceResult, error) {
+	s.mu.Lock()
+	if s.status == SUBCLOSED {
+		s.mu.Unlock()
+		return PresenceResult{}, ErrSubscriptionClosed
+	}
+	s.mu.Unlock()
+
 	resCh := make(chan PresenceResult, 1)
 	errCh := make(chan error, 1)
 	s.presence(func(result PresenceResult, err error) {
@@ -304,23 +325,38 @@ func (s *Subscription) presenceStats(fn func(PresenceStatsResult, error)) {
 
 // Unsubscribe allows to unsubscribe from channel.
 func (s *Subscription) Unsubscribe() error {
+	s.mu.Lock()
+	if s.status == SUBCLOSED {
+		s.mu.Unlock()
+		return ErrSubscriptionClosed
+	}
+	s.mu.Unlock()
+
 	s.triggerOnUnsubscribe(false, false)
 	s.centrifuge.unsubscribe(s.channel, func(result UnsubscribeResult, err error) {})
 	return nil
 }
 
 // Close remove subscription from client's subs map
-func (s *Subscription) Close() {
+func (s *Subscription) Close() error {
+	s.mu.Lock()
+	if s.status == SUBCLOSED {
+		s.mu.Unlock()
+		return ErrSubscriptionClosed
+	}
+	s.mu.Unlock()
 	s.status = SUBCLOSED
 	s.centrifuge.removeSubscription(s.channel)
+	return nil
 }
 
 // Subscribe allows to subscribe again after unsubscribing.
 func (s *Subscription) Subscribe() error {
+	s.mu.Lock()
 	if s.status == SUBCLOSED {
+		s.mu.Unlock()
 		return ErrSubscriptionClosed
 	}
-	s.mu.Lock()
 	s.needResubscribe = true
 	s.mu.Unlock()
 	if !s.centrifuge.connected() {

--- a/subscription.go
+++ b/subscription.go
@@ -123,6 +123,7 @@ const (
 	SUBSCRIBING
 	SUBSCRIBED
 	SUBERROR
+	SUBCLOSED
 )
 
 // Subscription represents client subscription to channel.
@@ -310,11 +311,15 @@ func (s *Subscription) Unsubscribe() error {
 
 // Close remove subscription from client's subs map
 func (s *Subscription) Close() {
+	s.status = SUBCLOSED
 	s.centrifuge.removeSubscription(s.channel)
 }
 
 // Subscribe allows to subscribe again after unsubscribing.
 func (s *Subscription) Subscribe() error {
+	if s.status == SUBCLOSED {
+		return ErrSubscribeClosed
+	}
 	s.mu.Lock()
 	s.needResubscribe = true
 	s.mu.Unlock()

--- a/subscription.go
+++ b/subscription.go
@@ -308,12 +308,16 @@ func (s *Subscription) Unsubscribe() error {
 	return nil
 }
 
+// Close remove subscription from client's subs map
+func (s *Subscription) Close() {
+	s.centrifuge.removeSubscription(s.channel)
+}
+
 // Subscribe allows to subscribe again after unsubscribing.
 func (s *Subscription) Subscribe() error {
 	s.mu.Lock()
 	s.needResubscribe = true
 	s.mu.Unlock()
-	s.centrifuge.storeSubscription(s)
 	if !s.centrifuge.connected() {
 		return nil
 	}


### PR DESCRIPTION
Automatic removing subscription object from client map on Unsubscribe.
https://github.com/centrifugal/centrifuge-go/issues/41