### PR TITLE
Memory align on 32bit arch

### DIFF
--- a/client.go
+++ b/client.go
@@ -41,6 +41,8 @@ type serverSub struct {
 // Close method to clean up state when you don't need client instance
 // anymore.
 type Client struct {
+	msgID               uint32
+	futureID            uint64
 	mu                  sync.RWMutex
 	url                 string
 	encoding            protocol.Type
@@ -50,7 +52,6 @@ type Client struct {
 	version             string
 	connectData         protocol.Raw
 	transport           transport
-	msgID               uint32
 	status              int
 	id                  string
 	subs                map[string]*Subscription
@@ -70,7 +71,6 @@ type Client struct {
 	delayPing           chan struct{}
 	reconnectCh         chan struct{}
 	closeCh             chan struct{}
-	futureID            uint64
 	connectFutures      map[uint64]connectFuture
 	hasBeenDisconnected bool
 	cbQueue             *cbQueue


### PR DESCRIPTION
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0xb7204c]

goroutine 36871 [running]:
runtime/internal/atomic.Xadd64(0x13f70614, 0x1, 0x0, 0xbc9440, 0x0)
        runtime/internal/atomic/asm_386.s:105 +0xc
github.com/centrifugal/centrifuge-go.(*Client).nextFutureID(...)
        github.com/centrifugal/centrifuge-go@v0.6.4/client.go:1217
github.com/centrifugal/centrifuge-go.(*Client).onConnect(0x13f70500, 0x172ec460)
        github.com/centrifugal/centrifuge-go@v0.6.4/client.go:1251 +0xde
github.com/centrifugal/centrifuge-go.(*Client).history(0x13f70500, 0x1487cc30, 0x44, 0x14234990)
        github.com/centrifugal/centrifuge-go@v0.6.4/client.go:1332 +0x6f
github.com/centrifugal/centrifuge-go.(*Subscription).history.func1(0x0, 0x0)
        github.com/centrifugal/centrifuge-go@v0.6.4/subscription.go:280 +0x6b
created by github.com/centrifugal/centrifuge-go.(*Subscription).onSubscribe
        github.com/centrifugal/centrifuge-go@v0.6.4/subscription.go:240 +0x1af