### PR TITLE
Introduce Error, set name/version over Config

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,24 @@
+v0.7.0
+======
+
+* Updated `github.com/centrifugal/protocol` package dependency to catch up with the latest changes in it
+* Introduced `Error` type which is used where we previously exposed `protocol.Error` – so there is no need to import `protocol` package in application code to investigate error code or message
+* Methods `Client.SetName` and `Client.SetVersion` removed in favour of `Name` and `Version` fields of `Config`
+
+```
+$ gorelease -base v0.6.5 -version v0.7.0
+github.com/centrifugal/centrifuge-go
+------------------------------------
+Incompatible changes:
+- (*Client).SetName: removed
+- (*Client).SetVersion: removed
+Compatible changes:
+- Config.Name: added
+- Config.Version: added
+- DefaultName: added
+- Error: added
+```
+
 v0.6.5
 ======
 

--- a/client.go
+++ b/client.go
@@ -48,8 +48,6 @@ type Client struct {
 	encoding            protocol.Type
 	config              Config
 	token               string
-	name                string
-	version             string
 	connectData         protocol.Raw
 	transport           transport
 	status              int
@@ -97,7 +95,6 @@ func New(u string, config Config) *Client {
 
 	c := &Client{
 		url:               u,
-		name:              defaultClientName,
 		config:            config,
 		status:            DISCONNECTED,
 		encoding:          encoding,
@@ -135,24 +132,6 @@ func (c *Client) SetToken(token string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.token = token
-}
-
-// SetName allows to set client name. You should only use a limited
-// amount of client names throughout your applications – i.e. don't
-// make it unique per user for example, this name describes environment
-// from which client connects.
-func (c *Client) SetName(name string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.name = name
-}
-
-// SetVersion allows to set client version. This is an application
-// specific information.
-func (c *Client) SetVersion(version string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.version = version
 }
 
 // SetConnectData allows to set data to send in connect command.
@@ -265,7 +244,7 @@ func (c *Client) rpc(method string, data []byte, fn func(RPCResult, error)) {
 			return
 		}
 		if r.Error != nil {
-			fn(RPCResult{}, r.Error)
+			fn(RPCResult{}, errorFromProto(r.Error))
 			return
 		}
 		var res protocol.RPCResult
@@ -924,7 +903,7 @@ func (c *Client) resubscribe(clientID string) error {
 }
 
 func isTokenExpiredError(err error) bool {
-	if e, ok := err.(*protocol.Error); ok && e.Code == 109 {
+	if e, ok := err.(*Error); ok && e.Code == 109 {
 		return true
 	}
 	return false
@@ -1050,7 +1029,7 @@ func (c *Client) sendSubRefresh(channel string, fn func(protocol.SubRefreshResul
 			return
 		}
 		if r.Error != nil {
-			fn(protocol.SubRefreshResult{}, r.Error)
+			fn(protocol.SubRefreshResult{}, errorFromProto(r.Error))
 			return
 		}
 		var res protocol.SubRefreshResult
@@ -1069,17 +1048,11 @@ func (c *Client) sendConnect(isReconnect bool, fn func(protocol.ConnectResult, e
 		Method: protocol.MethodTypeConnect,
 	}
 
-	if c.token != "" || c.connectData != nil || len(c.serverSubs) > 0 || c.name != "" || c.version != "" {
+	if c.token != "" || c.connectData != nil || len(c.serverSubs) > 0 || c.config.Name != "" || c.config.Version != "" {
 		params := &protocol.ConnectRequest{}
-		if c.token != "" {
-			params.Token = c.token
-		}
-		if c.name != "" {
-			params.Name = c.name
-		}
-		if c.version != "" {
-			params.Version = c.version
-		}
+		params.Token = c.token
+		params.Name = c.config.Name
+		params.Version = c.config.Version
 		if c.connectData != nil {
 			params.Data = c.connectData
 		}
@@ -1110,7 +1083,7 @@ func (c *Client) sendConnect(isReconnect bool, fn func(protocol.ConnectResult, e
 			return
 		}
 		if reply.Error != nil {
-			fn(protocol.ConnectResult{}, reply.Error)
+			fn(protocol.ConnectResult{}, errorFromProto(reply.Error))
 			return
 		}
 
@@ -1203,7 +1176,7 @@ func (c *Client) sendSubscribe(channel string, recover bool, streamPos streamPos
 			return
 		}
 		if reply.Error != nil {
-			fn(protocol.SubscribeResult{}, reply.Error)
+			fn(protocol.SubscribeResult{}, errorFromProto(reply.Error))
 			return
 		}
 		var res protocol.SubscribeResult
@@ -1316,7 +1289,7 @@ func (c *Client) sendPublish(channel string, data []byte, fn func(PublishResult,
 			return
 		}
 		if r.Error != nil {
-			fn(PublishResult{}, r.Error)
+			fn(PublishResult{}, errorFromProto(r.Error))
 			return
 		}
 		fn(PublishResult{}, nil)
@@ -1363,7 +1336,7 @@ func (c *Client) sendHistory(channel string, fn func(HistoryResult, error)) {
 			return
 		}
 		if r.Error != nil {
-			fn(HistoryResult{}, r.Error)
+			fn(HistoryResult{}, errorFromProto(r.Error))
 			return
 		}
 		var res protocol.HistoryResult
@@ -1421,7 +1394,7 @@ func (c *Client) sendPresence(channel string, fn func(PresenceResult, error)) {
 			return
 		}
 		if r.Error != nil {
-			fn(PresenceResult{}, r.Error)
+			fn(PresenceResult{}, errorFromProto(r.Error))
 			return
 		}
 		var res protocol.PresenceResult
@@ -1483,7 +1456,7 @@ func (c *Client) sendPresenceStats(channel string, fn func(PresenceStatsResult, 
 			return
 		}
 		if r.Error != nil {
-			fn(PresenceStatsResult{}, r.Error)
+			fn(PresenceStatsResult{}, errorFromProto(r.Error))
 			return
 		}
 		var res protocol.PresenceStatsResult
@@ -1540,7 +1513,7 @@ func (c *Client) sendUnsubscribe(channel string, fn func(UnsubscribeResult, erro
 			return
 		}
 		if r.Error != nil {
-			fn(UnsubscribeResult{}, r.Error)
+			fn(UnsubscribeResult{}, errorFromProto(r.Error))
 			return
 		}
 		var res protocol.UnsubscribeResult

--- a/client.go
+++ b/client.go
@@ -26,8 +26,6 @@ const (
 	CLOSED
 )
 
-const defaultClientName = "go"
-
 type serverSub struct {
 	Offset      uint64
 	Epoch       string

--- a/config.go
+++ b/config.go
@@ -8,17 +8,14 @@ import (
 	"time"
 )
 
+// Config defaults.
 const (
-	// DefaultHandshakeTimeout ...
-	DefaultHandshakeTimeout = time.Second
-	// DefaultReadTimeout ...
-	DefaultReadTimeout = 5 * time.Second
-	// DefaultWriteTimeout ...
-	DefaultWriteTimeout = time.Second
-	// DefaultPingInterval ...
-	DefaultPingInterval = 25 * time.Second
-	// DefaultPrivateChannelPrefix ...
+	DefaultHandshakeTimeout     = time.Second
+	DefaultReadTimeout          = 5 * time.Second
+	DefaultWriteTimeout         = time.Second
+	DefaultPingInterval         = 25 * time.Second
 	DefaultPrivateChannelPrefix = "$"
+	DefaultName                 = "go"
 )
 
 // Config contains various client options.
@@ -51,6 +48,14 @@ type Config struct {
 	CookieJar http.CookieJar
 	// Header specifies custom HTTP Header to send.
 	Header http.Header
+	// Name allows setting client name. You should only use a limited
+	// amount of client names throughout your applications – i.e. don't
+	// make it unique per user for example, this name semantically represents
+	// an environment from which client connects.
+	Name string
+	// Version allows setting client version. This is an application
+	// specific information. By default no version set.
+	Version string
 }
 
 // DefaultConfig returns Config with default options.
@@ -62,5 +67,6 @@ func DefaultConfig() Config {
 		HandshakeTimeout:     DefaultHandshakeTimeout,
 		PrivateChannelPrefix: DefaultPrivateChannelPrefix,
 		Header:               http.Header{},
+		Name:                 DefaultName,
 	}
 }

--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,8 @@
 package centrifuge
 
-import "errors"
+import (
+	"errors"
+)
 
 var (
 	// ErrTimeout returned if operation timed out.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/centrifugal/centrifuge-go
 go 1.13
 
 require (
-	github.com/centrifugal/protocol v0.3.4
+	github.com/centrifugal/protocol v0.3.5
 	github.com/gorilla/websocket v1.4.2
 	github.com/jpillora/backoff v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/centrifugal/protocol v0.3.4 h1:9q22iSp4CQOdQahfopvfmWWxDbj1Lo7ERG2j56mAxkE=
-github.com/centrifugal/protocol v0.3.4/go.mod h1:2YbBCaDwQHl37ErRdMrKSj18X2yVvpkQYtSX6aVbe5A=
+github.com/centrifugal/protocol v0.3.5 h1:3Tu1iNoKfEw5xkJotKm2or0vhyOl4HtfPbGSDnEWoGA=
+github.com/centrifugal/protocol v0.3.5/go.mod h1:2YbBCaDwQHl37ErRdMrKSj18X2yVvpkQYtSX6aVbe5A=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=

--- a/protocol.go
+++ b/protocol.go
@@ -1,6 +1,10 @@
 package centrifuge
 
-import "github.com/centrifugal/protocol"
+import (
+	"fmt"
+
+	"github.com/centrifugal/protocol"
+)
 
 // Publication is a data sent to channel.
 type Publication struct {
@@ -25,6 +29,19 @@ type ClientInfo struct {
 	// ChanInfo is an additional information about connection in context of
 	// channel subscription.
 	ChanInfo []byte
+}
+
+type Error struct {
+	Code    uint32
+	Message string
+}
+
+func errorFromProto(err *protocol.Error) *Error {
+	return &Error{Code: err.Code, Message: err.Message}
+}
+
+func (e Error) Error() string {
+	return fmt.Sprintf("%d: %s", e.Code, e.Message)
 }
 
 func newPushEncoder(enc protocol.Type) protocol.PushEncoder {

--- a/protocol.go
+++ b/protocol.go
@@ -31,6 +31,7 @@ type ClientInfo struct {
 	ChanInfo []byte
 }
 
+// Error represents protocol-level error.
 type Error struct {
 	Code    uint32
 	Message string


### PR DESCRIPTION
Related #47 

* Updated `github.com/centrifugal/protocol` package dependency to catch up with the latest changes in it
* Introduced `Error` type which is used where we previously exposed `protocol.Error` – so there is no need to import `protocol` package in application code to investigate error code or message
* Methods `Client.SetName` and `Client.SetVersion` removed in favour of `Name` and `Version` fields of `Config`

```
$ gorelease -base v0.6.5 -version v0.7.0
github.com/centrifugal/centrifuge-go
------------------------------------
Incompatible changes:
- (*Client).SetName: removed
- (*Client).SetVersion: removed
Compatible changes:
- Config.Name: added
- Config.Version: added
- DefaultName: added
- Error: added
```