### PR TITLE
fixing issues with benchmark Tests

### DIFF
--- a/examples/benchmark/main.go
+++ b/examples/benchmark/main.go
@@ -88,7 +88,9 @@ func main() {
 
 	startWg.Wait()
 	log.Printf("Starting benchmark [msgs=%d, msgsize=%d, pubs=%d, subs=%d]\n", *numMsg, *msgSize, *numPubs, *numSubs)
-	if waitForTestCompletion(&doneWg, deadline) {
+
+	testCompleted := waitForTestCompletion(&doneWg, deadline)
+	if testCompleted {
 		log.Printf("Test completed, generating report")
 	} else {
 		log.Printf("Deadline exceeded, proceeding with report generation")


### PR DESCRIPTION
I noticed 3 issues in the benchmark example code. 

-  When running the benchmark on a centrifuge-server running remotely, Clients reconnecting due to network issues causes the program to crash due to improper waitGroup actions
- When Clients reconnect, they can lose messages and can end up waiting for the messages to be received, indefinitely
- Converting the generated byte array for the payload to string before marshalling, converts the empty 0 bytes into the string representation, which is actually 6 times larger than the actual intended msg size. eg: ( [0] becomes "\u0000" )
ref : https://goplay.tools/snippet/tdq61T0axc_E

The fixes respectively are

- Call Done() on the waitGroup only on Client connects and not on reconnects by maintaining a connected flag
- Accept a deadline time as an argument and timeout the test if it is active beyond the deadline time and print the accumulated benchmark report
- Don't stringify the byte array before marshalling