### PR TITLE
feat(subscribe events): add Epoch,Offset

### DIFF
--- a/events.go
+++ b/events.go
@@ -17,6 +17,8 @@ type ServerSubscribeEvent struct {
 	Channel      string
 	Resubscribed bool
 	Recovered    bool
+	Epoch        string
+	Offset       uint64
 }
 
 // ServerJoinEvent has info about user who left channel.

--- a/subscription.go
+++ b/subscription.go
@@ -14,6 +14,8 @@ import (
 type SubscribeSuccessEvent struct {
 	Resubscribed bool
 	Recovered    bool
+	Epoch        string
+	Offset       uint64
 }
 
 // SubscribeErrorEvent is a subscribe error event context passed to
@@ -451,7 +453,12 @@ func (s *Subscription) subscribeSuccess(isResubscribe bool, res *protocol.Subscr
 	s.mu.Unlock()
 	if s.events != nil && s.events.onSubscribeSuccess != nil {
 		handler := s.events.onSubscribeSuccess
-		ev := SubscribeSuccessEvent{Resubscribed: isResubscribe, Recovered: res.Recovered}
+		ev := SubscribeSuccessEvent{
+			Resubscribed: isResubscribe,
+			Recovered:    res.Recovered,
+			Epoch:        res.Epoch,
+			Offset:       res.Offset,
+		}
 		s.centrifuge.runHandler(func() {
 			handler.OnSubscribeSuccess(s, ev)
 		})

--- a/subscription.go
+++ b/subscription.go
@@ -415,6 +415,13 @@ func (s *Subscription) Subscribe(opts ...SubscribeOption) error {
 	s.needResubscribe = true
 	s.mu.Unlock()
 	if !s.centrifuge.connected() {
+		if subscribeOpts.Since != nil {
+			s.mu.Lock()
+			s.recover = true
+			s.lastEpoch = subscribeOpts.Since.Epoch
+			s.lastOffset = subscribeOpts.Since.Offset
+			s.mu.Unlock()
+		}
 		return nil
 	}
 	return s.resubscribe(false, s.centrifuge.clientID(), *subscribeOpts)


### PR DESCRIPTION
This is PR against v0.8.3. Please create a branch like "0.8.x" and rebase this PR from master.

The Epoch field is required to be able to detect wrong position on subscribe.

Fixes #75
Fixes #76 