### PR TITLE
Protect map and queue variable access with mutex, add test

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -392,3 +392,76 @@ func TestClient_History(t *testing.T) {
 		t.Fatal("expected not available error, got " + strconv.FormatUint(uint64(e.Code), 10))
 	}
 }
+
+func TestConcurrentPublishSubscribe(t *testing.T) {
+	const (
+		numMessages        = 1000
+		numResubscritpions = 100
+	)
+
+	producer := NewJsonClient("ws://localhost:8000/connection/websocket?cf_protocol_version=v2", Config{})
+	defer producer.Close()
+
+	if err := producer.Connect(); err != nil {
+		t.Fatalf("error on connect: %v", err)
+	}
+
+	errChan := make(chan error)
+	defer close(errChan)
+	go func() {
+		for i := 0; i < numMessages; i++ {
+			msg := []byte(`{"unique":"` + randString(6) + strconv.FormatInt(time.Now().UnixNano(), 10) + `"}`)
+			_, err := producer.Publish(context.Background(), "test_concurrent", msg)
+			if err != nil {
+				errChan <- fmt.Errorf("error on publish: %v", err)
+				return
+			}
+		}
+		errChan <- nil
+	}()
+
+	go func() {
+		for i := 0; i < numResubscritpions; i++ {
+			consumer := NewJsonClient("ws://localhost:8000/connection/websocket?cf_protocol_version=v2", Config{})
+			if err := consumer.Connect(); err != nil {
+				errChan <- fmt.Errorf("error on connect: %v", err)
+				return
+			}
+
+			handler := &testSubscriptionHandler{}
+			sub, err := consumer.NewSubscription("test_concurrent")
+			if err != nil {
+				errChan <- fmt.Errorf("error on new subscription: %v (%d)", err, i)
+				return
+			}
+			sub.OnSubscribed(handler.OnSubscribe)
+			sub.OnPublication(handler.OnPublication)
+			if err := sub.Subscribe(); err != nil {
+				errChan <- fmt.Errorf("error on subscribe: %v (%d)", err, i)
+				return
+			}
+			sub2, err := consumer.NewSubscription("something_else")
+			if err != nil {
+				errChan <- fmt.Errorf("error on new subscription: %v (%d)", err, i)
+				return
+			}
+			sub2.OnSubscribed(handler.OnSubscribe)
+			sub2.OnPublication(handler.OnPublication)
+			if err := sub2.Subscribe(); err != nil {
+				errChan <- fmt.Errorf("error on subscribe: %v (%d)", err, i)
+				return
+			}
+		}
+		errChan <- nil
+	}()
+
+	var err error
+	for i := 0; i < 2; i++ {
+		if e := <-errChan; e != nil {
+			err = e
+		}
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This PR should fix a couple of possible races by adding mutex lock where variable access was not protected.

## Background:

I've got a race in centrifuge-go while running my application tests:

```
WARNING: DATA RACE
Write at 0x00c000488630 by goroutine 9:
  runtime.mapassign_faststr()
      /usr/local/go/src/runtime/map_faststr.go:203 +0x0
  github.com/centrifugal/centrifuge-go.(*Client).NewSubscription()
      /home/runner/go/pkg/mod/github.com/centrifugal/centrifuge-go@v0.9.6/client.go:191 +0x6bd
  github.com/pintu-crypto/exchange/backend/account/view/fake.TestFakeCentrifuge()
      /runner/_work/exchange/exchange/backend/account/view/fake/fake_test.go:176 +0x135e
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1629 +0x47

Previous read at 0x00c000488630 by goroutine 122:
  runtime.mapaccess2_faststr()
      /usr/local/go/src/runtime/map_faststr.go:108 +0x0
  github.com/centrifugal/centrifuge-go.(*Client).handlePush()
      /home/runner/go/pkg/mod/github.com/centrifugal/centrifuge-go@v0.9.6/client.go:699 +0x265
  github.com/centrifugal/centrifuge-go.(*Client).handle()
      /home/runner/go/pkg/mod/github.com/centrifugal/centrifuge-go@v0.9.6/client.go:667 +0x467
  github.com/centrifugal/centrifuge-go.(*Client).readOnce()
      /home/runner/go/pkg/mod/github.com/centrifugal/centrifuge-go@v0.9.6/client.go:605 +0x12a
  github.com/centrifugal/centrifuge-go.(*Client).reader()
      /home/runner/go/pkg/mod/github.com/centrifugal/centrifuge-go@v0.9.6/client.go:612 +0xad
  github.com/centrifugal/centrifuge-go.(*Client).startReconnecting.func5()
      /home/runner/go/pkg/mod/github.com/centrifugal/centrifuge-go@v0.9.6/client.go:950 +0x64
 ```

I believe the reason was an unprotected `c.subs` map read in `handlePush`. I added the test to reproduce and another race popped out in `runHandlerSync`, looks like `c.cbQueue`  also can be mutated concurrently, so I added mutex there too.

Please take a look.