### PR TITLE
[AXAGENT-1682] Add Proxy Lookup Function To Config

### DIFF
--- a/client.go
+++ b/client.go
@@ -873,6 +873,7 @@ func (c *Client) handleServerUnsub(channel string, _ *protocol.Unsubscribe) {
 func (c *Client) getReconnectDelay() time.Duration {
 	return c.reconnectStrategy.timeBeforeNextAttempt(c.reconnectAttempts)
 }
+type ProxyFunc = func(*http.Request) (*url.URL, error)
 
 func (c *Client) startReconnecting() error {
 	c.mu.Lock()
@@ -888,6 +889,7 @@ func (c *Client) startReconnecting() error {
 	c.mu.Unlock()
 
 	wsConfig := websocketConfig{
+		Proxy:			   c.config.Proxy,
 		NetDialContext:    c.config.NetDialContext,
 		TLSConfig:         c.config.TLSConfig,
 		HandshakeTimeout:  c.config.HandshakeTimeout,

--- a/client.go
+++ b/client.go
@@ -873,7 +873,6 @@ func (c *Client) handleServerUnsub(channel string, _ *protocol.Unsubscribe) {
 func (c *Client) getReconnectDelay() time.Duration {
 	return c.reconnectStrategy.timeBeforeNextAttempt(c.reconnectAttempts)
 }
-type ProxyFunc = func(*http.Request) (*url.URL, error)
 
 func (c *Client) startReconnecting() error {
 	c.mu.Lock()

--- a/client.go
+++ b/client.go
@@ -888,7 +888,7 @@ func (c *Client) startReconnecting() error {
 	c.mu.Unlock()
 
 	wsConfig := websocketConfig{
-		Proxy:			   c.config.Proxy,
+		Proxy:             c.config.Proxy,
 		NetDialContext:    c.config.NetDialContext,
 		TLSConfig:         c.config.TLSConfig,
 		HandshakeTimeout:  c.config.HandshakeTimeout,

--- a/config.go
+++ b/config.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"net"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -30,6 +31,9 @@ type Config struct {
 	// Version allows setting client version. This is an application
 	// specific information. By default, no version set.
 	Version string
+	// Proxy specifies the function responsible for determining the proxy URL. If
+	// Proxy is nil, http.ProxyFromEnvironment is used.
+	Proxy func(*http.Request) (*url.URL, error)
 	// NetDialContext specifies the dial function for creating TCP connections. If
 	// NetDialContext is nil, net.DialContext is used.
 	NetDialContext func(ctx context.Context, network, addr string) (net.Conn, error)


### PR DESCRIPTION
Added a proxy lookup function to the centrifuge client to enable customizations of proxies vs relying on the default `http.ProxyFromEnvironment` functionality.