### PR TITLE
Add HTTP Proxy lookup function support

### DIFF
--- a/client.go
+++ b/client.go
@@ -99,6 +99,7 @@ func newClient(endpoint string, isProtobuf bool, config Config) *Client {
 	if config.Name == "" {
 		config.Name = "go"
 	}
+
 	// We support setting multiple endpoints to try in round-robin fashion. But
 	// for now this feature is not documented and used for internal tests. In most
 	// cases there should be a single public server WS endpoint.
@@ -888,6 +889,7 @@ func (c *Client) startReconnecting() error {
 	c.mu.Unlock()
 
 	wsConfig := websocketConfig{
+		Proxy:             c.config.Proxy,
 		NetDialContext:    c.config.NetDialContext,
 		TLSConfig:         c.config.TLSConfig,
 		HandshakeTimeout:  c.config.HandshakeTimeout,

--- a/config.go
+++ b/config.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"net"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -30,6 +31,8 @@ type Config struct {
 	// Version allows setting client version. This is an application
 	// specific information. By default, no version set.
 	Version string
+	// Proxy specifies the function responsible for determining the proxy URL.
+	Proxy func(*http.Request) (*url.URL, error)
 	// NetDialContext specifies the dial function for creating TCP connections. If
 	// NetDialContext is nil, net.DialContext is used.
 	NetDialContext func(ctx context.Context, network, addr string) (net.Conn, error)

--- a/config.go
+++ b/config.go
@@ -31,7 +31,10 @@ type Config struct {
 	// Version allows setting client version. This is an application
 	// specific information. By default, no version set.
 	Version string
-	// Proxy specifies the function responsible for determining the proxy URL.
+	// Proxy specifies a function to return a proxy for a given Request.
+	// If the function returns a non-nil error, the request is aborted with the
+	// provided error. If function returns a nil *URL, no proxy is used.
+	// If Proxy is nil then http.ProxyFromEnvironment will be used.
 	Proxy func(*http.Request) (*url.URL, error)
 	// NetDialContext specifies the dial function for creating TCP connections. If
 	// NetDialContext is nil, net.DialContext is used.

--- a/transport_websocket.go
+++ b/transport_websocket.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -62,6 +63,9 @@ type websocketTransport struct {
 
 // websocketConfig configures Websocket transport.
 type websocketConfig struct {
+	// Proxy specifies the function responsible for determining the proxy URL.
+	Proxy func(*http.Request) (*url.URL, error)
+
 	// NetDialContext specifies the dial function for creating TCP connections. If
 	// NetDialContext is nil, net.DialContext is used.
 	NetDialContext func(ctx context.Context, network, addr string) (net.Conn, error)
@@ -92,7 +96,7 @@ func newWebsocketTransport(url string, protocolType protocol.Type, config websoc
 	wsHeaders := config.Header
 
 	dialer := &websocket.Dialer{}
-	dialer.Proxy = http.ProxyFromEnvironment
+	dialer.Proxy = config.Proxy
 	dialer.NetDialContext = config.NetDialContext
 
 	dialer.HandshakeTimeout = config.HandshakeTimeout

--- a/transport_websocket.go
+++ b/transport_websocket.go
@@ -63,7 +63,10 @@ type websocketTransport struct {
 
 // websocketConfig configures Websocket transport.
 type websocketConfig struct {
-	// Proxy specifies the function responsible for determining the proxy URL.
+	// Proxy specifies a function to return a proxy for a given Request.
+	// If the function returns a non-nil error, the request is aborted with the
+	// provided error. If function returns a nil *URL, no proxy is used.
+	// If Proxy is nil then http.ProxyFromEnvironment will be used.
 	Proxy func(*http.Request) (*url.URL, error)
 
 	// NetDialContext specifies the dial function for creating TCP connections. If
@@ -96,7 +99,11 @@ func newWebsocketTransport(url string, protocolType protocol.Type, config websoc
 	wsHeaders := config.Header
 
 	dialer := &websocket.Dialer{}
-	dialer.Proxy = config.Proxy
+	if config.Proxy != nil {
+		dialer.Proxy = config.Proxy
+	} else {
+		dialer.Proxy = http.ProxyFromEnvironment
+	}
 	dialer.NetDialContext = config.NetDialContext
 
 	dialer.HandshakeTimeout = config.HandshakeTimeout


### PR DESCRIPTION
Added a proxy lookup function to the centrifuge client to enable customizations of proxies vs relying on the default http.ProxyFromEnvironment functionality.