### PR TITLE
add Unwrap method to allow to detect root cause error with errors.Is

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Start Centrifugo
-        run: docker run -d -p 8000:8000 centrifugo/centrifugo:latest centrifugo --client_insecure
+        run: docker run -d -p 8000:8000 centrifugo/centrifugo:latest centrifugo --client.insecure
 
       - name: Test
-        run: sleep 3; go test -race -v
+        run: go test -race -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
         run: docker run -d -p 8000:8000 centrifugo/centrifugo:latest centrifugo --client_insecure
 
       - name: Test
-        run: go test -race -v
+        run: sleep 3; go test -race -v

--- a/errors.go
+++ b/errors.go
@@ -33,12 +33,20 @@ func (t TransportError) Error() string {
 	return fmt.Sprintf("transport error: %v", t.Err)
 }
 
+func (t TransportError) Unwrap() error {
+	return t.Err
+}
+
 type ConnectError struct {
 	Err error
 }
 
 func (c ConnectError) Error() string {
 	return fmt.Sprintf("connect error: %v", c.Err)
+}
+
+func (c ConnectError) Unwrap() error {
+	return c.Err
 }
 
 type RefreshError struct {
@@ -49,12 +57,20 @@ func (r RefreshError) Error() string {
 	return fmt.Sprintf("refresh error: %v", r.Err)
 }
 
+func (r RefreshError) Unwrap() error {
+	return r.Err
+}
+
 type ConfigurationError struct {
 	Err error
 }
 
-func (r ConfigurationError) Error() string {
-	return fmt.Sprintf("configuration error: %v", r.Err)
+func (c ConfigurationError) Error() string {
+	return fmt.Sprintf("configuration error: %v", c.Err)
+}
+
+func (c ConfigurationError) Unwrap() error {
+	return c.Err
 }
 
 type SubscriptionSubscribeError struct {
@@ -65,10 +81,18 @@ func (s SubscriptionSubscribeError) Error() string {
 	return fmt.Sprintf("subscribe error: %v", s.Err)
 }
 
+func (s SubscriptionSubscribeError) Unwrap() error {
+	return s.Err
+}
+
 type SubscriptionRefreshError struct {
 	Err error
 }
 
 func (s SubscriptionRefreshError) Error() string {
 	return fmt.Sprintf("refresh error: %v", s.Err)
+}
+
+func (s SubscriptionRefreshError) Unwrap() error {
+	return s.Err
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,73 @@
+package centrifuge_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/centrifugal/centrifuge-go"
+)
+
+func TestErrors(t *testing.T) {
+	cases := []struct {
+		name      string
+		rootError error
+		factory   func(err error) error
+	}{
+		{
+			name:      "SubscriptionSubscribeError",
+			rootError: centrifuge.ErrTimeout,
+			factory: func(err error) error {
+				return centrifuge.SubscriptionSubscribeError{Err: err}
+			},
+		},
+		{
+			name:      "SubscriptionRefreshError",
+			rootError: centrifuge.ErrUnauthorized,
+			factory: func(err error) error {
+				return centrifuge.SubscriptionRefreshError{Err: err}
+			},
+		},
+		{
+			name:      "ConfigurationError",
+			rootError: centrifuge.ErrClientClosed,
+			factory: func(err error) error {
+				return centrifuge.ConfigurationError{Err: err}
+			},
+		},
+		{
+			name:      "RefreshError",
+			rootError: centrifuge.ErrClientClosed,
+			factory: func(err error) error {
+				return centrifuge.RefreshError{Err: err}
+			},
+		},
+		{
+			name:      "ConnectError",
+			rootError: centrifuge.ErrClientClosed,
+			factory: func(err error) error {
+				return centrifuge.ConnectError{Err: err}
+			},
+		},
+		{
+			name:      "TransportError",
+			rootError: centrifuge.ErrClientClosed,
+			factory: func(err error) error {
+				return centrifuge.TransportError{Err: err}
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.factory(c.rootError)
+			parts := strings.Split(err.Error(), ": ")
+			if parts[1] != c.rootError.Error() {
+				t.Errorf("unexpected error string: %v", err)
+			}
+
+			if !errors.Is(err, c.rootError) {
+				t.Errorf("expected root error to be wrapped")
+			}
+		})
+	}
+}


### PR DESCRIPTION
We realised that detecting certain types of errors does not work as expected because error types are missing `Unwrap` method required for `errors.Is` to work:

```go
	sub.OnError(func(e centrifuge.SubscriptionErrorEvent) {
		if errors.Is(e.Error, centrifuge.ErrUnauthorized) {
			// We never got here, even though Unauthorized error is logged.
		}
		log.Error(e.Error)
	})
```
This PR adds corresponding methods to error types in `errors.go` and a corresponding test (fails without Unwrap, but works with it in place). I suspect it may be not required for some types like ConfigError, but adding the method anyway for uniformity.

Also changed a `--client_insecure` to `--client.insecure` in the workflow as old flag no longer works with latest centrifuge (this leads to workflows failing).