### PR TITLE
Possible panic fix

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -353,7 +353,7 @@ func TestConcurrentCloseDisconnect(t *testing.T) {
 		}
 		sub.OnUnsubscribed(func(UnsubscribedEvent) {})
 		sub.OnSubscribing(func(SubscribingEvent) {})
-		sub.Subscribe()
+		_ = sub.Subscribe()
 		go client.Close()
 		client.handleDisconnect(&disconnect{
 			Code:      connectingTransportClosed,


### PR DESCRIPTION
I have encountered a panic in production, I believe it happened when some kind of network error happened concurrently with normal `client.Close()` on a client that had some callbacks in the queue.

My theory is that `client.Close` set `c.cbQueue = nil` at the same time as `client.handleDisconnect` running in a goroutine attempted to push to the queue. This is how test fails before my "fix":

```shell
$ go test -v -count=1 -run ^TestConcurrentCloseDisconnect$ .
=== RUN   TestConcurrentCloseDisconnect
--- FAIL: TestConcurrentCloseDisconnect (2.20s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x102950e00]

goroutine 5 [running]:
testing.tRunner.func1.2({0x102a8ea40, 0x102dc9c30})
        /opt/homebrew/Cellar/go/1.24.2/libexec/src/testing/testing.go:1734 +0x1ac
testing.tRunner.func1()
        /opt/homebrew/Cellar/go/1.24.2/libexec/src/testing/testing.go:1737 +0x334
panic({0x102a8ea40?, 0x102dc9c30?})
        /opt/homebrew/Cellar/go/1.24.2/libexec/src/runtime/panic.go:792 +0x124
github.com/centrifugal/centrifuge-go.(*cbQueue).pushOrClose(0x140022ce5a8?, 0x102630bb4?, 0x8?)
        /Users/user/work/experiments/centrifuge-go/queue.go:73 +0x20
github.com/centrifugal/centrifuge-go.(*cbQueue).push(...)
        /Users/user/work/experiments/centrifuge-go/queue.go:58
github.com/centrifugal/centrifuge-go.(*Client).runHandlerAsync(...)
        /Users/user/work/experiments/centrifuge-go/client.go:783
github.com/centrifugal/centrifuge-go.(*Subscription).moveToSubscribing(0x140022ce5a0, 0x1, {0x1029a2325, 0x10})
        /Users/user/work/experiments/centrifuge-go/subscription.go:452 +0x1e0
github.com/centrifugal/centrifuge-go.(*Client).moveToDisconnected(0x1400221ed88, 0x1, {0x1029a2325, 0x10})
        /Users/user/work/experiments/centrifuge-go/client.go:465 +0x4d0
github.com/centrifugal/centrifuge-go.(*Client).handleDisconnect(0x140022ce5a0?, 0x10299fcb0?)
        /Users/user/work/experiments/centrifuge-go/client.go:734 +0x80
github.com/centrifugal/centrifuge-go.TestConcurrentCloseDisconnect(0x14000003500)
        /Users/user/work/experiments/centrifuge-go/client_test.go:358 +0x68
testing.tRunner(0x14000003500, 0x102b0d710)
        /opt/homebrew/Cellar/go/1.24.2/libexec/src/testing/testing.go:1792 +0xe4
created by testing.(*T).Run in goroutine 1
        /opt/homebrew/Cellar/go/1.24.2/libexec/src/testing/testing.go:1851 +0x374
FAIL    github.com/centrifugal/centrifuge-go    3.200s
FAIL
```

I am not sure that my "fix" is a proper one though, as callbacks won't be run in case `Close` has happened before.
I suspect there is a better solution.