### PR TITLE
fix tracing enabled when log level is LogLevelNone

### DIFF
--- a/client.go
+++ b/client.go
@@ -88,7 +88,7 @@ func NewProtobufClient(endpoint string, config Config) *Client {
 }
 
 func (c *Client) logLevelEnabled(level LogLevel) bool {
-	return level >= c.config.LogLevel
+	return c.config.LogLevel > LogLevelNone && level >= c.config.LogLevel
 }
 
 func (c *Client) log(level LogLevel, message string, fields map[string]string) {

--- a/client_test.go
+++ b/client_test.go
@@ -649,3 +649,56 @@ func TestHandlePublishFossil(t *testing.T) {
 		testFossil(t, client)
 	})
 }
+
+func TestLogLevel(t *testing.T) {
+	cases := []struct {
+		name            string
+		configuredLevel LogLevel
+		requestedLevel  LogLevel
+		enabled         bool
+	}{
+		{
+			"configured with debug, requested trace",
+			LogLevelDebug,
+			LogLevelTrace,
+			false,
+		},
+		{
+			"configured with none, requested trace",
+			LogLevelNone,
+			LogLevelTrace,
+			false,
+		},
+		{
+			"configured with none, requested dabug",
+			LogLevelNone,
+			LogLevelDebug,
+			false,
+		},
+		{
+			"configured with trace, requested debug",
+			LogLevelTrace,
+			LogLevelDebug,
+			true,
+		},
+		{
+			"configured with debug, requested debug",
+			LogLevelDebug,
+			LogLevelDebug,
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := NewJsonClient("ws://localhost:9000/connection/websocket", Config{
+				LogLevel: tc.configuredLevel,
+			})
+
+			got := client.logLevelEnabled(tc.requestedLevel)
+			if got != tc.enabled {
+				t.Errorf("expected %v got %v", tc.enabled, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I noticed a significant CPU time spent in `traceInPush` even though my log level is `LogLevelNone`.

The core issue is that log level constants are not ordered in a consistent way (neither high to low, nor low to high):

```go
LogLevelNone LogLevel = iota	// 0 - is no logging
LogLevelTrace			// 1 - max verbosity
LogLevelDebug			// 2 - high verbosity
```

Because of this, check `level >= c.config.LogLevel` does not work as expected in `logLevelEnabled` and for clients with LogLevel not specified (zero value is LogLevelNone) `logLevelEnabled` always returns true.
Fixing the order of constants would be a proper fix, but can possibly break some users code depending on numerical values.
Instead I add explicit check for `LogLevelNone` in `logLevelEnabled`. This should be backwards compatible, unless users actually expect `LogLevelNone` to be equal to `LogLevelTrace`.