### PR TITLE
Allow configuring min/max delays for backoff strategies

### DIFF
--- a/client.go
+++ b/client.go
@@ -188,7 +188,7 @@ func newClient(endpoint string, isProtobuf bool, config Config) *Client {
 		subs:              make(map[string]*Subscription),
 		serverSubs:        make(map[string]*serverSub),
 		requests:          make(map[uint32]request),
-		reconnectStrategy: defaultBackoffReconnect,
+		reconnectStrategy: newBackoffReconnect(config.MinReconnectDelay, config.MaxReconnectDelay),
 		delayPing:         make(chan struct{}, 32),
 		events:            newEventHub(),
 		connectFutures:    make(map[uint64]connectFuture),

--- a/config.go
+++ b/config.go
@@ -51,6 +51,13 @@ type Config struct {
 	// MaxServerPingDelay used to set maximum delay of ping from server.
 	// Zero value means 10 * time.Second.
 	MaxServerPingDelay time.Duration
+	// MinReconnectDelay is the minimum delay between reconnection attempts.
+	// This delay is jittered.
+	// Zero value means 200 * time.Millisecond.
+	MinReconnectDelay time.Duration
+	// MaxReconnectDelay is the maximum delay between reconnection attempts.
+	// Zero value means 20 * time.Second.
+	MaxReconnectDelay time.Duration
 	// TLSConfig specifies the TLS configuration to use with tls.Client.
 	// If nil, the default configuration is used.
 	TLSConfig *tls.Config

--- a/reconnect.go
+++ b/reconnect.go
@@ -37,3 +37,20 @@ func (r *backoffReconnect) timeBeforeNextAttempt(attempt int) time.Duration {
 	}
 	return b.ForAttempt(float64(attempt))
 }
+
+// newBackoffReconnect creates a new backoff reconnect strategy with custom min and max delays.
+// If minDelay or maxDelay is zero, it uses the default values.
+func newBackoffReconnect(minDelay, maxDelay time.Duration) reconnectStrategy {
+	if minDelay == 0 {
+		minDelay = 200 * time.Millisecond
+	}
+	if maxDelay == 0 {
+		maxDelay = 20 * time.Second
+	}
+	return &backoffReconnect{
+		MinDelay: minDelay,
+		MaxDelay: maxDelay,
+		Factor:   2,
+		Jitter:   true,
+	}
+}

--- a/reconnect.go
+++ b/reconnect.go
@@ -21,13 +21,6 @@ type backoffReconnect struct {
 	MaxDelay time.Duration
 }
 
-var defaultBackoffReconnect = &backoffReconnect{
-	MinDelay: 200 * time.Millisecond,
-	MaxDelay: 20 * time.Second,
-	Factor:   2,
-	Jitter:   true,
-}
-
 func (r *backoffReconnect) timeBeforeNextAttempt(attempt int) time.Duration {
 	b := &backoff.Backoff{
 		Min:    r.MinDelay,


### PR DESCRIPTION
Relates #116 

* Added `MinReconnectDelay` and `MaxReconnectDelay` fields to `Config` struct for controlling client reconnection timing
* Added `MinResubscribeDelay` and `MaxResubscribeDelay` fields to `SubscriptionConfig` for controlling subscription retry timing

Default values match currently used default backoff reconnect strategy.