### PR TITLE
Fix wrong handler nil check and swapped godoc comments

### DIFF
--- a/client.go
+++ b/client.go
@@ -1343,7 +1343,7 @@ func (c *Client) startReconnecting() error {
 		for ch := range c.serverSubs {
 			if _, ok := res.Subs[ch]; !ok {
 				var serverUnsubscribedHandler ServerUnsubscribedHandler
-				if c.events != nil && c.events.onServerSubscribing != nil {
+				if c.events != nil && c.events.onServerUnsubscribed != nil {
 					serverUnsubscribedHandler = c.events.onServerUnsubscribed
 				}
 				if serverUnsubscribedHandler != nil {

--- a/client_events.go
+++ b/client_events.go
@@ -17,6 +17,7 @@ type ServerPublicationEvent struct {
 	Publication
 }
 
+// ServerSubscribedEvent has info about server-side subscription.
 type ServerSubscribedEvent struct {
 	Channel        string
 	WasRecovering  bool
@@ -27,13 +28,13 @@ type ServerSubscribedEvent struct {
 	Data           []byte
 }
 
-// ServerJoinEvent has info about user who left channel.
+// ServerJoinEvent has info about user who joined channel.
 type ServerJoinEvent struct {
 	Channel string
 	ClientInfo
 }
 
-// ServerLeaveEvent has info about user who joined channel.
+// ServerLeaveEvent has info about user who left channel.
 type ServerLeaveEvent struct {
 	Channel string
 	ClientInfo


### PR DESCRIPTION
- Fix bug: onServerUnsubscribed handler was guarded by checking onServerSubscribing instead of onServerUnsubscribed, which could cause the unsubscribed handler to not fire during reconnect.
- Fix swapped godoc comments on ServerJoinEvent and ServerLeaveEvent.
- Add missing godoc comment for ServerSubscribedEvent.