### PR TITLE
Add docker-compose.yml for test dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Start Centrifugo
-        run: docker run -d -p 8000:8000 -e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_DELTA_PUBLISH=true -e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_ALLOWED_DELTA_TYPES="fossil" -e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_HISTORY_SIZE="100" -e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_HISTORY_TTL="300s" -e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_FORCE_RECOVERY="true" centrifugo/centrifugo:v6 centrifugo --client.insecure
+        run: docker compose up -d
 
       - name: Test
         run: go test -race -v

--- a/README.md
+++ b/README.md
@@ -52,16 +52,10 @@ If you are calling `Publish`, `RPC`, `History`, `Presence`, `PresenceStats` from
 
 ## Run tests
 
-First run Centrifugo instance:
+Start Centrifugo and run tests:
 
 ```
-docker run -it --rm -p 8000:8000 \
--e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_DELTA_PUBLISH=true \
--e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_ALLOWED_DELTA_TYPES="fossil" \
--e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_HISTORY_SIZE="100" \
--e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_HISTORY_TTL="300s" \
--e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_FORCE_RECOVERY="true" \
-centrifugo/centrifugo:v6 centrifugo --client.insecure
+docker compose up -d
+go test -race -v
+docker compose down
 ```
-
-Then run `go test`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  centrifugo:
+    image: centrifugo/centrifugo:v6
+    command: centrifugo --client.insecure
+    ports:
+      - "8000:8000"
+    environment:
+      CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_DELTA_PUBLISH: "true"
+      CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_ALLOWED_DELTA_TYPES: "fossil"
+      CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_HISTORY_SIZE: "100"
+      CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_HISTORY_TTL: "300s"
+      CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_FORCE_RECOVERY: "true"


### PR DESCRIPTION
## Summary
- Add `docker-compose.yml` with Centrifugo v6 service configuration for running integration tests
- Update CI workflow to use `docker compose up -d` instead of inline `docker run` command
- Simplify README test instructions to use docker compose

## Test plan
- [ ] Verify CI passes with `docker compose up -d` starting Centrifugo
- [ ] Verify local `docker compose up -d && go test -race -v` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)