### PR TITLE
Replace sync.Cond with channel in cb queue

### DIFF
--- a/client.go
+++ b/client.go
@@ -201,8 +201,8 @@ func newClient(endpoint string, isProtobuf bool, config Config) *Client {
 	// Queue to run callbacks on.
 	client.cbQueue = &cbQueue{
 		closeCh: make(chan struct{}),
+		notify:  make(chan struct{}, 1),
 	}
-	client.cbQueue.cond = sync.NewCond(&client.cbQueue.mu)
 	go client.cbQueue.dispatch()
 	if client.config.LogLevel > 0 {
 		go client.handleLogs()

--- a/client_test.go
+++ b/client_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"math/rand"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -648,6 +650,292 @@ func TestHandlePublishFossil(t *testing.T) {
 		_ = client.Connect()
 		testFossil(t, client)
 	})
+}
+
+// fastReconnectConfig returns a Config with short reconnect delays so stress
+// tests do not spend most of their time waiting for backoff timers.
+func fastReconnectConfig() Config {
+	return Config{
+		MinReconnectDelay: 50 * time.Millisecond,
+		MaxReconnectDelay: 200 * time.Millisecond,
+		ReadTimeout:       2 * time.Second,
+		HandshakeTimeout:  time.Second,
+	}
+}
+
+// TestStress_CloseWhileReconnecting verifies that Close() called while the
+// client is in a reconnect loop (bad server address) always completes promptly
+// and never hangs. This is the scenario that triggered issue #105: the cbQueue
+// dispatch goroutine must not stall between reconnect attempts.
+func TestStress_CloseWhileReconnecting(t *testing.T) {
+	const iterations = 30
+	for i := 0; i < iterations; i++ {
+		client := NewJsonClient("ws://localhost:9000/connection/websocket", fastReconnectConfig())
+		client.OnConnecting(func(ConnectingEvent) {})
+		client.OnError(func(ErrorEvent) {})
+		_ = client.Connect()
+
+		// Randomise how long the reconnect loop runs before we shut it down.
+		time.Sleep(time.Duration(rand.Intn(15)) * time.Millisecond)
+
+		done := make(chan struct{})
+		go func() {
+			client.Close()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("iteration %d: Close() hung while client was reconnecting", i)
+		}
+	}
+}
+
+// TestStress_ConcurrentCloseWhileReconnecting is the same scenario as above
+// but Close() is called from several goroutines simultaneously to surface
+// races on the client state machine and the cbQueue.
+func TestStress_ConcurrentCloseWhileReconnecting(t *testing.T) {
+	const iterations = 20
+	const closers = 5
+	for i := 0; i < iterations; i++ {
+		client := NewJsonClient("ws://localhost:9000/connection/websocket", fastReconnectConfig())
+		client.OnConnecting(func(ConnectingEvent) {})
+		client.OnError(func(ErrorEvent) {})
+		_ = client.Connect()
+		time.Sleep(time.Duration(rand.Intn(10)) * time.Millisecond)
+
+		var wg sync.WaitGroup
+		for j := 0; j < closers; j++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				client.Close()
+			}()
+		}
+		done := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("iteration %d: concurrent Close() calls hung", i)
+		}
+	}
+}
+
+// TestStress_RepeatedForcedReconnects connects to a real server and forces N
+// disconnect-then-reconnect cycles, waiting for a successful reconnect each
+// time. It verifies the reconnect path — including cbQueue handler dispatch —
+// completes reliably under repeated churn and that every cycle fires exactly
+// one connected event.
+func TestStress_RepeatedForcedReconnects(t *testing.T) {
+	const cycles = 25
+
+	var connectedCount atomic.Int32
+	connectedCh := make(chan struct{}, cycles+1)
+
+	client := NewJsonClient(
+		"ws://localhost:8000/connection/websocket?cf_protocol_version=v2",
+		fastReconnectConfig(),
+	)
+	defer client.Close()
+	client.OnConnecting(func(ConnectingEvent) {})
+	client.OnConnected(func(ConnectedEvent) {
+		connectedCount.Add(1)
+		connectedCh <- struct{}{}
+	})
+	client.OnError(func(ErrorEvent) {})
+
+	_ = client.Connect()
+	select {
+	case <-connectedCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("initial connect timed out")
+	}
+
+	for i := 0; i < cycles; i++ {
+		client.handleDisconnect(&disconnect{
+			Code:      connectingTransportClosed,
+			Reason:    "stress-test-forced-disconnect",
+			Reconnect: true,
+		})
+		select {
+		case <-connectedCh:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("cycle %d: reconnect timed out", i)
+		}
+	}
+
+	if got := int(connectedCount.Load()); got != cycles+1 {
+		t.Fatalf("expected %d connected events, got %d", cycles+1, got)
+	}
+}
+
+// TestStress_AllHandlersDuringReconnect registers every available client
+// handler, forces many reconnect cycles and verifies that the handler call
+// counts are self-consistent: every connecting event must be followed by
+// exactly one connected event, and the cbQueue must never stall even with
+// all handler slots occupied.
+func TestStress_AllHandlersDuringReconnect(t *testing.T) {
+	const cycles = 20
+
+	var (
+		connectingCount atomic.Int32
+		connectedCount  atomic.Int32
+		errorCount      atomic.Int32
+	)
+	connectedCh := make(chan struct{}, cycles+1)
+
+	client := NewJsonClient(
+		"ws://localhost:8000/connection/websocket?cf_protocol_version=v2",
+		fastReconnectConfig(),
+	)
+	defer client.Close()
+
+	client.OnConnecting(func(ConnectingEvent) { connectingCount.Add(1) })
+	client.OnConnected(func(ConnectedEvent) {
+		connectedCount.Add(1)
+		connectedCh <- struct{}{}
+	})
+	client.OnDisconnected(func(DisconnectedEvent) {})
+	client.OnError(func(e ErrorEvent) { errorCount.Add(1) })
+
+	_ = client.Connect()
+	select {
+	case <-connectedCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("initial connect timed out")
+	}
+
+	for i := 0; i < cycles; i++ {
+		client.handleDisconnect(&disconnect{
+			Code:      connectingTransportClosed,
+			Reason:    "stress-test-forced-disconnect",
+			Reconnect: true,
+		})
+		select {
+		case <-connectedCh:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("cycle %d: reconnect timed out (connecting=%d connected=%d)",
+				i, connectingCount.Load(), connectedCount.Load())
+		}
+	}
+
+	if got, want := int(connectedCount.Load()), cycles+1; got != want {
+		t.Fatalf("connected events: got %d, want %d", got, want)
+	}
+	// Every reconnect fires a connecting event; the initial Connect() also does.
+	if got := int(connectingCount.Load()); got < cycles+1 {
+		t.Fatalf("connecting events: got %d, want at least %d", got, cycles+1)
+	}
+}
+
+// TestStress_ReconnectWithSlowHandlers verifies that the reconnect loop
+// completes even when every handler sleeps briefly. This guards against
+// regressions where a slow handler permanently stalls runHandlerSync and
+// prevents scheduleReconnectLocked from being reached.
+func TestStress_ReconnectWithSlowHandlers(t *testing.T) {
+	const cycles = 10
+	const handlerDelay = 5 * time.Millisecond
+
+	connectedCh := make(chan struct{}, cycles+1)
+
+	client := NewJsonClient(
+		"ws://localhost:8000/connection/websocket?cf_protocol_version=v2",
+		fastReconnectConfig(),
+	)
+	defer client.Close()
+
+	client.OnConnecting(func(ConnectingEvent) { time.Sleep(handlerDelay) })
+	client.OnConnected(func(ConnectedEvent) {
+		time.Sleep(handlerDelay)
+		connectedCh <- struct{}{}
+	})
+	client.OnError(func(ErrorEvent) { time.Sleep(handlerDelay) })
+
+	_ = client.Connect()
+	select {
+	case <-connectedCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("initial connect timed out")
+	}
+
+	for i := 0; i < cycles; i++ {
+		client.handleDisconnect(&disconnect{
+			Code:      connectingTransportClosed,
+			Reason:    "stress-test-forced-disconnect",
+			Reconnect: true,
+		})
+		// Allow extra time per cycle for the handler delays.
+		select {
+		case <-connectedCh:
+		case <-time.After(15 * time.Second):
+			t.Fatalf("cycle %d: reconnect timed out with slow handlers", i)
+		}
+	}
+}
+
+// TestStress_ReconnectWithSubscriptions subscribes to a channel, forces many
+// reconnects and verifies that the subscription resubscribes successfully after
+// each one. This exercises the interaction between the reconnect path, the
+// cbQueue and subscription state management under churn.
+func TestStress_ReconnectWithSubscriptions(t *testing.T) {
+	const cycles = 15
+
+	connectedCh := make(chan struct{}, cycles+1)
+	subscribedCh := make(chan struct{}, cycles+1)
+
+	client := NewJsonClient(
+		"ws://localhost:8000/connection/websocket?cf_protocol_version=v2",
+		fastReconnectConfig(),
+	)
+	defer client.Close()
+
+	sub, err := client.NewSubscription("stress_reconnect_sub")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sub.OnSubscribed(func(SubscribedEvent) { subscribedCh <- struct{}{} })
+	sub.OnSubscribing(func(SubscribingEvent) {})
+	sub.OnUnsubscribed(func(UnsubscribedEvent) {})
+
+	client.OnConnecting(func(ConnectingEvent) {})
+	client.OnConnected(func(ConnectedEvent) { connectedCh <- struct{}{} })
+	client.OnError(func(ErrorEvent) {})
+
+	_ = client.Connect()
+	_ = sub.Subscribe()
+
+	select {
+	case <-connectedCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("initial connect timed out")
+	}
+	select {
+	case <-subscribedCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("initial subscribe timed out")
+	}
+
+	for i := 0; i < cycles; i++ {
+		client.handleDisconnect(&disconnect{
+			Code:      connectingTransportClosed,
+			Reason:    "stress-test-forced-disconnect",
+			Reconnect: true,
+		})
+		select {
+		case <-connectedCh:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("cycle %d: reconnect timed out", i)
+		}
+		select {
+		case <-subscribedCh:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("cycle %d: resubscribe timed out", i)
+		}
+	}
 }
 
 func TestLogLevel(t *testing.T) {

--- a/queue.go
+++ b/queue.go
@@ -12,7 +12,7 @@ import (
 // license: see https://github.com/nats-io/nats.go/blob/master/LICENSE.
 type cbQueue struct {
 	mu      sync.Mutex
-	cond    *sync.Cond
+	notify  chan struct{}
 	head    *asyncCB
 	tail    *asyncCB
 	closeCh chan struct{}
@@ -30,17 +30,19 @@ type asyncCB struct {
 func (q *cbQueue) dispatch() {
 	for {
 		q.mu.Lock()
-		// Protect for spurious wake-ups. We should get out of the
-		// wait only if there is an element to pop from the list.
-		for q.head == nil {
-			q.cond.Wait()
-		}
 		curr := q.head
-		q.head = curr.next
-		if curr == q.tail {
-			q.tail = nil
+		if curr != nil {
+			q.head = curr.next
+			if curr == q.tail {
+				q.tail = nil
+			}
 		}
 		q.mu.Unlock()
+
+		if curr == nil {
+			<-q.notify
+			continue
+		}
 
 		// This signals that the dispatcher has been closed and all
 		// previous callbacks have been dispatched.
@@ -89,8 +91,9 @@ func (q *cbQueue) pushOrClose(f func(time.Duration), close bool) {
 	q.tail = cb
 	if close {
 		q.closed = true
-		q.cond.Broadcast()
-	} else {
-		q.cond.Signal()
+	}
+	select {
+	case q.notify <- struct{}{}:
+	default:
 	}
 }

--- a/queue_test.go
+++ b/queue_test.go
@@ -2,6 +2,7 @@ package centrifuge
 
 import (
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -19,11 +20,10 @@ func assertEqual(t *testing.T, expected, actual interface{}, msg string) {
 }
 
 func newTestQueue() *cbQueue {
-	q := &cbQueue{
+	return &cbQueue{
 		closeCh: make(chan struct{}),
+		notify:  make(chan struct{}, 1),
 	}
-	q.cond = sync.NewCond(&q.mu)
-	return q
 }
 
 func TestCbQueue_PushAndDispatch(t *testing.T) {
@@ -128,4 +128,166 @@ func TestCbQueue_PushNilCallbackPanics(t *testing.T) {
 	}()
 
 	q.pushOrClose(nil, false)
+}
+
+// TestCbQueue_SignalNotLostBetweenUnlockAndWait exercises the window that
+// differs from the old sync.Cond implementation: in the new code there is a
+// brief gap between releasing the mutex and blocking on the notify channel
+// where a push can arrive. The buffered channel must absorb that signal so
+// dispatch does not miss it and stall.
+//
+// We force the race by making the in-flight callback hold up dispatch while
+// we enqueue the next item, so dispatch will definitely reach the channel-wait
+// with an already-buffered signal rather than an empty channel.
+func TestCbQueue_SignalNotLostBetweenUnlockAndWait(t *testing.T) {
+	q := newTestQueue()
+	go q.dispatch()
+
+	// Block dispatch inside the first callback until we have pushed the
+	// second item, ensuring the notify signal is sent before dispatch can
+	// loop back and check the queue.
+	secondPushed := make(chan struct{})
+	firstDone := make(chan struct{})
+	secondDone := make(chan struct{})
+
+	q.push(func(_ time.Duration) {
+		// Signal that the second item has been enqueued, then wait until
+		// the test confirms it before returning — this keeps dispatch busy
+		// so it will hit the channel-wait with the signal already buffered.
+		<-secondPushed
+		close(firstDone)
+	})
+
+	q.push(func(_ time.Duration) {
+		close(secondDone)
+	})
+	close(secondPushed) // let the first callback return
+
+	select {
+	case <-secondDone:
+	case <-time.After(time.Second):
+		t.Fatal("second callback was never dispatched; notify signal may have been lost")
+	}
+	<-firstDone
+}
+
+// TestCbQueue_DrainBeforeClose verifies that all callbacks already in the queue
+// are executed before close() returns — the backwards-compatibility guarantee.
+func TestCbQueue_DrainBeforeClose(t *testing.T) {
+	q := newTestQueue()
+	go q.dispatch()
+
+	const n = 100
+	var count atomic.Int32
+	for i := 0; i < n; i++ {
+		q.push(func(_ time.Duration) {
+			count.Add(1)
+		})
+	}
+
+	q.close()
+
+	if got := count.Load(); got != n {
+		t.Fatalf("expected %d callbacks executed before close, got %d", n, got)
+	}
+}
+
+// TestCbQueue_CloseEmptyQueue verifies that close() on an idle queue
+// completes promptly without hanging.
+func TestCbQueue_CloseEmptyQueue(t *testing.T) {
+	q := newTestQueue()
+	go q.dispatch()
+
+	done := make(chan struct{})
+	go func() {
+		q.close()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("close() hung on empty queue")
+	}
+}
+
+// TestCbQueue_ConcurrentPushers verifies that callbacks from many concurrent
+// goroutines are all dispatched exactly once.
+func TestCbQueue_ConcurrentPushers(t *testing.T) {
+	q := newTestQueue()
+	go q.dispatch()
+
+	const goroutines = 10
+	const perGoroutine = 50
+	var count atomic.Int32
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perGoroutine; j++ {
+				q.push(func(_ time.Duration) {
+					count.Add(1)
+				})
+			}
+		}()
+	}
+	wg.Wait()
+	q.close()
+
+	if got := count.Load(); got != goroutines*perGoroutine {
+		t.Fatalf("expected %d callbacks, got %d", goroutines*perGoroutine, got)
+	}
+}
+
+// TestCbQueue_SignalNotLostUnderRapidPush pushes many items without any pause,
+// exercising the path where multiple pushes share a single buffered signal and
+// dispatch must drain the entire queue before waiting again.
+func TestCbQueue_SignalNotLostUnderRapidPush(t *testing.T) {
+	q := newTestQueue()
+	go q.dispatch()
+
+	const n = 1000
+	var count atomic.Int32
+	for i := 0; i < n; i++ {
+		q.push(func(_ time.Duration) {
+			count.Add(1)
+		})
+	}
+	q.close()
+
+	if got := count.Load(); got != n {
+		t.Fatalf("expected %d callbacks, got %d", n, got)
+	}
+}
+
+// TestCbQueue_CallbacksRunSerially verifies that dispatch never executes two
+// callbacks concurrently — a property callers depend on for ordering.
+func TestCbQueue_CallbacksRunSerially(t *testing.T) {
+	q := newTestQueue()
+	go q.dispatch()
+
+	const n = 200
+	var active atomic.Int32
+	var overlap bool
+	var mu sync.Mutex
+
+	for i := 0; i < n; i++ {
+		q.push(func(_ time.Duration) {
+			if active.Add(1) > 1 {
+				mu.Lock()
+				overlap = true
+				mu.Unlock()
+			}
+			time.Sleep(time.Microsecond) // give scheduler a chance to interleave
+			active.Add(-1)
+		})
+	}
+	q.close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if overlap {
+		t.Fatal("two callbacks ran concurrently — dispatch is not serial")
+	}
 }


### PR DESCRIPTION
Fixes #105.

### Problem

On certain Windows configurations using S0 Low Power Idle sleep, clients would
enter the connecting state after waking from hibernation and never open a
websocket again. The reconnect loop stalled permanently.

The root cause is OS-level: `sync.Cond.Wait` internally parks the goroutine
using a Windows synchronization primitive. On some hardware/driver combinations,
that primitive does not reliably wake the goroutine after hibernation resumes,
even when `Signal` is called. With `dispatch` stuck, any `runHandlerSync` call
(used in the reconnect path for error and connecting handlers) blocks forever,
so `scheduleReconnectLocked` is never reached and no new websocket is opened.

The `sync.Cond` usage in `cbQueue` is logically correct — the `for head == nil`
guard around `Wait` means a lost signal can never cause permanent blocking under
normal scheduler behaviour. The failure is specific to certain Windows power
states interacting with the Go runtime's OS thread after resume.

### Fix

Replace `sync.Cond` with a buffered channel of size 1 as the wake signal.

```
notify chan struct{}   // replaces cond *sync.Cond
```

When `pushOrClose` adds an item it does a non-blocking send:

```go
select {
case q.notify <- struct{}{}:
default:
}
```

`dispatch` pops under the lock, then if the queue was empty waits on the
channel:

```go
q.mu.Lock()
curr := q.head
if curr != nil { /* pop */ }
q.mu.Unlock()

if curr == nil {
    <-q.notify
    continue
}
```

A buffered channel stores the signal in Go runtime memory rather than in an OS
primitive, so it survives hibernation resume regardless of how the OS schedules
threads. If a push arrives in the brief gap between the mutex unlock and the
channel receive, the signal sits in the buffer and is consumed immediately on
the next receive — no item is ever lost.

### Behaviour compatibility

All observable semantics are identical to the previous implementation:

| Property | Before | After |
|---|---|---|
| Callbacks dispatched in push order | yes | yes |
| At most one callback runs at a time | yes | yes |
| All pending callbacks drain before `close()` returns | yes | yes |
| Pushes after `close()` are silently dropped | yes | yes |

The one internal difference is that `dispatch` no longer holds the mutex while
idle — the mutex is released before the channel receive. This opens a brief
window where a concurrent push can arrive before `dispatch` reaches `<-q.notify`,
but the buffered channel absorbs that signal correctly.

### Tests added

| Test | What it covers |
|---|---|
| `TestCbQueue_SignalNotLostBetweenUnlockAndWait` | Forces a push to arrive while dispatch is busy so the signal lands in the buffer before the channel-wait; directly exercises the new gap between unlock and receive |
| `TestCbQueue_DrainBeforeClose` | All 100 pending callbacks execute before `close()` returns |
| `TestCbQueue_CloseEmptyQueue` | `close()` on an idle queue does not hang |
| `TestCbQueue_ConcurrentPushers` | 10 goroutines × 50 pushes = 500 callbacks, all dispatched exactly once |
| `TestCbQueue_SignalNotLostUnderRapidPush` | 1000 rapid pushes share a single buffered signal; dispatch drains the full queue without missing any |
| `TestCbQueue_CallbacksRunSerially` | Two callbacks never overlap — dispatch remains strictly single-threaded |
