### PR TITLE
Support publication filtering by tags

### DIFF
--- a/client.go
+++ b/client.go
@@ -283,6 +283,9 @@ func (c *Client) NewSubscription(channel string, config ...SubscriptionConfig) (
 	if _, ok := c.subs[channel]; ok {
 		return nil, ErrDuplicateSubscription
 	}
+	if len(config) == 1 && config[0].TagsFilter != nil && config[0].Delta != DeltaTypeNone {
+		return nil, errors.New("cannot use delta and tags filter together")
+	}
 	sub = newSubscription(c, channel, config...)
 	c.subs[channel] = sub
 	return sub, nil
@@ -1674,7 +1677,7 @@ type StreamPosition struct {
 
 func (c *Client) sendSubscribe(
 	channel string, data []byte, recover bool, streamPos StreamPosition, token string,
-	positioned bool, recoverable bool, joinLeave bool, deltaType DeltaType, flag int64,
+	positioned bool, recoverable bool, joinLeave bool, deltaType DeltaType, tagsFilter *FilterNode, flag int64,
 	fn func(res *protocol.SubscribeResult, err error),
 ) error {
 	params := &protocol.SubscribeRequest{
@@ -1697,6 +1700,10 @@ func (c *Client) sendSubscribe(
 
 	if deltaType != DeltaTypeNone {
 		params.Delta = string(deltaType)
+	}
+
+	if tagsFilter != nil {
+		params.Tf = tagsFilter.node
 	}
 
 	cmd := &protocol.Command{

--- a/filter.go
+++ b/filter.go
@@ -1,0 +1,79 @@
+package centrifuge
+
+import "github.com/centrifugal/protocol"
+
+// FilterNode is a node in a publication tags-filter expression tree, used for
+// server-side publication filtering. Build instances with the Filter* helpers
+// and pass the result via SubscriptionConfig.TagsFilter or
+// Subscription.SetTagsFilter.
+//
+// A filter is either a leaf node (a comparison such as ticker == "AAPL") or a
+// logical node combining child nodes with and/or/not. The server evaluates the
+// filter against each publication's tags and delivers only matching
+// publications. See https://centrifugal.dev/docs/server/publication_filtering.
+//
+// Publication filtering must be enabled for the namespace on the server
+// (allow_tags_filter) and cannot be combined with delta compression.
+type FilterNode struct {
+	node *protocol.FilterNode
+}
+
+func leafFilter(key, cmp, val string, vals []string) *FilterNode {
+	return &FilterNode{node: &protocol.FilterNode{Key: key, Cmp: cmp, Val: val, Vals: vals}}
+}
+
+func logicalFilter(op string, nodes []*FilterNode) *FilterNode {
+	children := make([]*protocol.FilterNode, 0, len(nodes))
+	for _, n := range nodes {
+		children = append(children, n.node)
+	}
+	return &FilterNode{node: &protocol.FilterNode{Op: op, Nodes: children}}
+}
+
+// FilterEq matches when tag key equals val.
+func FilterEq(key, val string) *FilterNode { return leafFilter(key, "eq", val, nil) }
+
+// FilterNeq matches when tag key does not equal val.
+func FilterNeq(key, val string) *FilterNode { return leafFilter(key, "neq", val, nil) }
+
+// FilterIn matches when tag key is one of vals.
+func FilterIn(key string, vals ...string) *FilterNode { return leafFilter(key, "in", "", vals) }
+
+// FilterNin matches when tag key is not one of vals.
+func FilterNin(key string, vals ...string) *FilterNode { return leafFilter(key, "nin", "", vals) }
+
+// FilterExists matches when tag key exists.
+func FilterExists(key string) *FilterNode { return leafFilter(key, "ex", "", nil) }
+
+// FilterNotExists matches when tag key does not exist.
+func FilterNotExists(key string) *FilterNode { return leafFilter(key, "nex", "", nil) }
+
+// FilterStartsWith matches when string tag key starts with val.
+func FilterStartsWith(key, val string) *FilterNode { return leafFilter(key, "sw", val, nil) }
+
+// FilterEndsWith matches when string tag key ends with val.
+func FilterEndsWith(key, val string) *FilterNode { return leafFilter(key, "ew", val, nil) }
+
+// FilterContains matches when string tag key contains val.
+func FilterContains(key, val string) *FilterNode { return leafFilter(key, "ct", val, nil) }
+
+// FilterGt matches when numeric tag key is greater than val.
+func FilterGt(key, val string) *FilterNode { return leafFilter(key, "gt", val, nil) }
+
+// FilterGte matches when numeric tag key is greater than or equal to val.
+func FilterGte(key, val string) *FilterNode { return leafFilter(key, "gte", val, nil) }
+
+// FilterLt matches when numeric tag key is less than val.
+func FilterLt(key, val string) *FilterNode { return leafFilter(key, "lt", val, nil) }
+
+// FilterLte matches when numeric tag key is less than or equal to val.
+func FilterLte(key, val string) *FilterNode { return leafFilter(key, "lte", val, nil) }
+
+// FilterAnd matches when all nodes match.
+func FilterAnd(nodes ...*FilterNode) *FilterNode { return logicalFilter("and", nodes) }
+
+// FilterOr matches when at least one of nodes matches.
+func FilterOr(nodes ...*FilterNode) *FilterNode { return logicalFilter("or", nodes) }
+
+// FilterNot inverts node.
+func FilterNot(node *FilterNode) *FilterNode { return logicalFilter("not", []*FilterNode{node}) }

--- a/filter_test.go
+++ b/filter_test.go
@@ -1,0 +1,179 @@
+package centrifuge
+
+// Tests for publication filtering (server-side filtering by publication tags).
+// The Filter* helpers build a protocol FilterNode tree; the subscribe request
+// carries it in the Tf field. The feature requires Centrifugo PRO / namespace
+// config, so wire-level behavior is exercised against the in-process FakeServer.
+
+import (
+	"testing"
+)
+
+func TestFilterBuilderLeafNodes(t *testing.T) {
+	cases := []struct {
+		node    *FilterNode
+		wantCmp string
+		wantVal string
+	}{
+		{FilterEq("ticker", "AAPL"), "eq", "AAPL"},
+		{FilterNeq("source", "TEST"), "neq", "TEST"},
+		{FilterExists("price"), "ex", ""},
+		{FilterNotExists("internal_id"), "nex", ""},
+		{FilterStartsWith("ticker", "AA"), "sw", "AA"},
+		{FilterEndsWith("source", "DAQ"), "ew", "DAQ"},
+		{FilterContains("category", "ec"), "ct", "ec"},
+		{FilterGt("price", "100"), "gt", "100"},
+		{FilterGte("volume", "1000"), "gte", "1000"},
+		{FilterLt("price", "200"), "lt", "200"},
+		{FilterLte("volume", "1000"), "lte", "1000"},
+	}
+	for _, c := range cases {
+		if c.node.node.Cmp != c.wantCmp {
+			t.Fatalf("cmp = %q, want %q", c.node.node.Cmp, c.wantCmp)
+		}
+		if c.node.node.Val != c.wantVal {
+			t.Fatalf("val = %q, want %q", c.node.node.Val, c.wantVal)
+		}
+	}
+}
+
+func TestFilterBuilderSetMembership(t *testing.T) {
+	in := FilterIn("category", "tech", "finance")
+	if in.node.Cmp != "in" || len(in.node.Vals) != 2 || in.node.Vals[0] != "tech" {
+		t.Fatalf("unexpected in node: %+v", in.node)
+	}
+	nin := FilterNin("ticker", "MSFT", "GOOGL")
+	if nin.node.Cmp != "nin" || len(nin.node.Vals) != 2 {
+		t.Fatalf("unexpected nin node: %+v", nin.node)
+	}
+}
+
+func TestFilterBuilderLogicalNodes(t *testing.T) {
+	filter := FilterAnd(
+		FilterEq("ticker", "AAPL"),
+		FilterGte("price", "100"),
+		FilterIn("source", "NASDAQ", "NYSE"),
+	)
+	if filter.node.Op != "and" || len(filter.node.Nodes) != 3 {
+		t.Fatalf("unexpected and node: %+v", filter.node)
+	}
+	if filter.node.Nodes[0].Key != "ticker" || filter.node.Nodes[2].Cmp != "in" {
+		t.Fatalf("unexpected and children: %+v", filter.node.Nodes)
+	}
+
+	or := FilterOr(FilterEq("ticker", "MSFT"), FilterEq("category", "tech"))
+	if or.node.Op != "or" || len(or.node.Nodes) != 2 {
+		t.Fatalf("unexpected or node: %+v", or.node)
+	}
+
+	not := FilterNot(FilterEq("source", "NYSE"))
+	if not.node.Op != "not" || len(not.node.Nodes) != 1 || not.node.Nodes[0].Cmp != "eq" {
+		t.Fatalf("unexpected not node: %+v", not.node)
+	}
+}
+
+func TestNewSubscriptionRejectsDeltaWithTagsFilter(t *testing.T) {
+	client := NewProtobufClient("ws://localhost:0/connection/websocket", Config{})
+	defer client.Close()
+	_, err := client.NewSubscription("market:stocks", SubscriptionConfig{
+		Delta:      DeltaTypeFossil,
+		TagsFilter: FilterEq("ticker", "AAPL"),
+	})
+	if err == nil {
+		t.Fatal("expected error combining delta and tags filter")
+	}
+}
+
+func TestSetTagsFilterRejectsDeltaCombination(t *testing.T) {
+	client := NewProtobufClient("ws://localhost:0/connection/websocket", Config{})
+	defer client.Close()
+	sub, err := client.NewSubscription("market:stocks", SubscriptionConfig{Delta: DeltaTypeFossil})
+	if err != nil {
+		t.Fatalf("new subscription: %v", err)
+	}
+	if err := sub.SetTagsFilter(FilterEq("ticker", "AAPL")); err == nil {
+		t.Fatal("expected error combining delta and tags filter")
+	}
+}
+
+func TestSubscribeRequestCarriesTagsFilter(t *testing.T) {
+	server := NewFakeServer(t)
+	client := NewProtobufClient(server.URL(), Config{})
+	t.Cleanup(client.Close)
+
+	sub, err := client.NewSubscription("market:stocks", SubscriptionConfig{
+		TagsFilter: FilterAnd(
+			FilterEq("ticker", "AAPL"),
+			FilterGte("price", "100"),
+		),
+	})
+	if err != nil {
+		t.Fatalf("new subscription: %v", err)
+	}
+	subscribedCh := make(chan SubscribedEvent, 1)
+	sub.OnSubscribed(func(e SubscribedEvent) { subscribedCh <- e })
+
+	_ = client.Connect()
+	_ = sub.Subscribe()
+	waitCh(t, subscribedCh, "subscribed")
+
+	tf := server.LastSubscribe().Tf
+	if tf == nil {
+		t.Fatal("subscribe request must carry the tags filter")
+	}
+	if tf.Op != "and" || len(tf.Nodes) != 2 {
+		t.Fatalf("unexpected tf: %+v", tf)
+	}
+	if tf.Nodes[0].Key != "ticker" || tf.Nodes[0].Cmp != "eq" || tf.Nodes[0].Val != "AAPL" {
+		t.Fatalf("unexpected tf leaf: %+v", tf.Nodes[0])
+	}
+	if tf.Nodes[1].Cmp != "gte" {
+		t.Fatalf("unexpected tf leaf: %+v", tf.Nodes[1])
+	}
+}
+
+func TestSetTagsFilterAppliesOnSubscribe(t *testing.T) {
+	server := NewFakeServer(t)
+	client := NewProtobufClient(server.URL(), Config{})
+	t.Cleanup(client.Close)
+
+	sub, err := client.NewSubscription("market:stocks", SubscriptionConfig{})
+	if err != nil {
+		t.Fatalf("new subscription: %v", err)
+	}
+	if err := sub.SetTagsFilter(FilterEq("ticker", "BTC")); err != nil {
+		t.Fatalf("set tags filter: %v", err)
+	}
+	subscribedCh := make(chan SubscribedEvent, 1)
+	sub.OnSubscribed(func(e SubscribedEvent) { subscribedCh <- e })
+
+	_ = client.Connect()
+	_ = sub.Subscribe()
+	waitCh(t, subscribedCh, "subscribed")
+
+	tf := server.LastSubscribe().Tf
+	if tf == nil || tf.Key != "ticker" || tf.Val != "BTC" {
+		t.Fatalf("unexpected tf: %+v", tf)
+	}
+}
+
+func TestSubscribeWithoutFilterSendsNoTf(t *testing.T) {
+	server := NewFakeServer(t)
+	client := NewProtobufClient(server.URL(), Config{})
+	t.Cleanup(client.Close)
+
+	sub, err := client.NewSubscription("market:stocks", SubscriptionConfig{})
+	if err != nil {
+		t.Fatalf("new subscription: %v", err)
+	}
+	subscribedCh := make(chan SubscribedEvent, 1)
+	sub.OnSubscribed(func(e SubscribedEvent) { subscribedCh <- e })
+
+	_ = client.Connect()
+	_ = sub.Subscribe()
+	waitCh(t, subscribedCh, "subscribed")
+
+	if tf := server.LastSubscribe().Tf; tf != nil {
+		t.Fatalf("expected no tags filter, got %+v", tf)
+	}
+}

--- a/subscription.go
+++ b/subscription.go
@@ -50,6 +50,11 @@ type SubscriptionConfig struct {
 	JoinLeave bool
 	// Delta allows to specify delta type for the subscription. By default, no delta is used.
 	Delta DeltaType
+	// TagsFilter sets a server-side publication filter based on publication tags.
+	// When set, the server delivers only publications whose tags match the
+	// filter. Must be enabled for the namespace on the server (allow_tags_filter)
+	// and cannot be combined with Delta. Build with the Filter* helpers.
+	TagsFilter *FilterNode
 	// MinResubscribeDelay is the minimum delay between resubscription attempts.
 	// This delay is jittered.
 	// Zero value means 200 * time.Millisecond.
@@ -114,6 +119,7 @@ func newSubscription(c *Client, channel string, config ...SubscriptionConfig) *S
 		s.recoverable = cfg.Recoverable
 		s.joinLeave = cfg.JoinLeave
 		s.deltaType = cfg.Delta
+		s.tagsFilter = cfg.TagsFilter
 		s.getState = cfg.GetState
 	}
 	return s
@@ -156,6 +162,10 @@ type Subscription struct {
 	deltaType       DeltaType
 	deltaNegotiated bool
 	prevData        []byte
+
+	// tagsFilter is the server-side publication tags filter (nil if unset).
+	// Guarded by mu.
+	tagsFilter *FilterNode
 
 	// pushID is the numeric channel ID assigned by the server when channel
 	// compaction is negotiated. Pushes then carry this ID instead of the
@@ -429,6 +439,19 @@ func (s *Subscription) unsubscribe(code uint32, reason string, sendUnsubscribe b
 			}
 		})
 	}
+}
+
+// SetTagsFilter sets the server-side publication tags filter. It is applied on
+// the next subscribe attempt, not the current one. Pass nil to clear it. Cannot
+// be combined with delta compression. Build with the Filter* helpers.
+func (s *Subscription) SetTagsFilter(tagsFilter *FilterNode) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if tagsFilter != nil && s.deltaType != DeltaTypeNone {
+		return errors.New("cannot use delta and tags filter together")
+	}
+	s.tagsFilter = tagsFilter
+	return nil
 }
 
 // Subscribe allows initiating subscription process.
@@ -931,7 +954,7 @@ func (s *Subscription) continueResubscribe() {
 	// of an otherwise valid reply.
 	connGeneration := s.centrifuge.connGeneration.Load()
 
-	err := s.centrifuge.sendSubscribe(s.Channel, s.data, isRecover, sp, token, s.positioned, s.recoverable, s.joinLeave, s.deltaType, flag, func(res *protocol.SubscribeResult, err error) {
+	err := s.centrifuge.sendSubscribe(s.Channel, s.data, isRecover, sp, token, s.positioned, s.recoverable, s.joinLeave, s.deltaType, s.tagsFilter, flag, func(res *protocol.SubscribeResult, err error) {
 		if err != nil {
 			s.inflight.Store(false)
 			s.subscribeError(err)


### PR DESCRIPTION
Adds support for [publication filtering](https://centrifugal.dev/docs/server/publication_filtering) by publication tags.

A subscription can carry a tags filter so the server delivers only publications whose tags match it — reducing bandwidth and client-side processing.

### API

- `Filter*` builders: `FilterEq`, `FilterNeq`, `FilterIn`, `FilterNin`, `FilterExists`, `FilterNotExists`, `FilterStartsWith`, `FilterEndsWith`, `FilterContains`, `FilterGt`, `FilterGte`, `FilterLt`, `FilterLte`, `FilterAnd`, `FilterOr`, `FilterNot`.
- `SubscriptionConfig.TagsFilter` to set at creation.
- `Subscription.SetTagsFilter(...)` to set/replace before the next subscribe (pass `nil` to clear).
- Mutually exclusive with delta compression (validated).

### Example

```go
sub, _ := client.NewSubscription("market:stocks", centrifuge.SubscriptionConfig{
    TagsFilter: centrifuge.FilterAnd(
        centrifuge.FilterEq("ticker", "AAPL"),
        centrifuge.FilterGte("price", "100"),
    ),
})
```

Tests added in `filter_test.go`: builder unit tests plus fake-server wire tests asserting the subscribe request carries the `Tf` field (and sends none when unset).
