### PR TITLE
Support state invalidation

### DIFF
--- a/client.go
+++ b/client.go
@@ -749,6 +749,24 @@ func (c *Client) clearConnectedState() {
 	}
 }
 
+// invalidateConnectionState handles a "state invalidated" disconnect (code
+// 3014): it drops the connection token (so a fresh one is fetched via GetToken
+// on reconnect, via refreshRequired) and invalidates every subscription's
+// cached state. The actual reconnect is performed by the caller.
+func (c *Client) invalidateConnectionState() {
+	c.mu.Lock()
+	c.token = ""
+	c.refreshRequired = true
+	subs := make([]*Subscription, 0, len(c.subs))
+	for _, s := range c.subs {
+		subs = append(subs, s)
+	}
+	c.mu.Unlock()
+	for _, s := range subs {
+		s.invalidateState()
+	}
+}
+
 func (c *Client) handleDisconnect(d *disconnect) {
 	if d == nil {
 		d = &disconnect{
@@ -756,6 +774,11 @@ func (c *Client) handleDisconnect(d *disconnect) {
 			Reason:    "transport closed",
 			Reconnect: true,
 		}
+	}
+	if d.Code == disconnectedStateInvalidated {
+		// State invalidated delivered as a WebSocket close frame (the usual
+		// path; the Disconnect-push path is handled in handlePush).
+		c.invalidateConnectionState()
 	}
 	if d.Reconnect {
 		c.moveToConnecting(d.Code, d.Reason)
@@ -960,6 +983,9 @@ func (c *Client) handlePush(push *protocol.Push) {
 		return
 	case push.Disconnect != nil:
 		code := push.Disconnect.Code
+		if code == disconnectedStateInvalidated {
+			c.invalidateConnectionState()
+		}
 		reconnect := code < 3500 || code >= 5000 || (code >= 4000 && code < 4500)
 		if reconnect {
 			c.moveToConnecting(code, push.Disconnect.Reason)

--- a/codes.go
+++ b/codes.go
@@ -40,3 +40,23 @@ const (
 // Server error code returned when recovery from the provided position is
 // impossible (only sent when subscriptionFlagRejectUnrecovered was requested).
 const errorCodeUnrecoverablePosition uint32 = 112
+
+// Server-sent "state invalidated" codes. The server determines that the
+// cached state and/or token are no longer valid and asks the client to drop
+// them and re-sync.
+const (
+	// unsubscribedStateInvalidated is sent in an Unsubscribe push for a single
+	// subscription. The client clears the subscription token and cached state
+	// and resubscribes (it's >= 2500, so resubscribe applies).
+	unsubscribedStateInvalidated uint32 = 2502
+	// disconnectedStateInvalidated is sent in a Disconnect push for the whole
+	// connection. The client clears the connection token (to force getToken),
+	// invalidates all subscriptions' state, and reconnects.
+	disconnectedStateInvalidated uint32 = 3014
+)
+
+// stateInvalidatedEpoch is a sentinel recovery epoch used after state
+// invalidation: the client resubscribes with recover=true and this epoch, which
+// the server can never match, so the reply reports WasRecovering=true,
+// Recovered=false — the application then reloads via its recovery-failure path.
+const stateInvalidatedEpoch = "_"

--- a/state_invalidation_test.go
+++ b/state_invalidation_test.go
@@ -1,0 +1,131 @@
+package centrifuge
+
+// Tests for "state invalidated" handling: unsubscribe code 2502 (per-subscription)
+// and disconnect code 3014 (connection-wide). On these the client drops cached
+// tokens and the fossil delta base so a fresh token is obtained and state is
+// re-synced. Exercised against the in-process FakeServer.
+
+import (
+	"testing"
+)
+
+func TestInvalidateStateClearsTokenAndDeltaBase(t *testing.T) {
+	server := NewFakeServer(t)
+	client := NewProtobufClient(server.URL(), Config{})
+	t.Cleanup(client.Close)
+
+	sub, err := client.NewSubscription("ch", SubscriptionConfig{Token: "sub-token"})
+	if err != nil {
+		t.Fatalf("new subscription: %v", err)
+	}
+	sub.prevData = []byte("stale-delta-base")
+	sub.offset = 10
+	sub.epoch = "e1"
+	sub.recover = true
+
+	sub.invalidateState()
+
+	if sub.token != "" {
+		t.Fatalf("token must be cleared, got %q", sub.token)
+	}
+	if sub.prevData != nil {
+		t.Fatalf("delta base must be cleared, got %q", sub.prevData)
+	}
+	// Recovery position is reset to a deliberately unrecoverable one: recover
+	// stays true with the sentinel epoch, so the resubscribe reports
+	// WasRecovering=true, Recovered=false.
+	if !sub.recover || sub.offset != 0 || sub.epoch != stateInvalidatedEpoch {
+		t.Fatalf("recovery position must be reset to the unrecoverable sentinel, got offset=%d epoch=%q recover=%v", sub.offset, sub.epoch, sub.recover)
+	}
+}
+
+func TestInvalidateConnectionStateClearsTokenAndAllSubs(t *testing.T) {
+	server := NewFakeServer(t)
+	client := NewProtobufClient(server.URL(), Config{Token: "conn-token"})
+	t.Cleanup(client.Close)
+
+	sub, err := client.NewSubscription("ch", SubscriptionConfig{Token: "sub-token"})
+	if err != nil {
+		t.Fatalf("new subscription: %v", err)
+	}
+	sub.prevData = []byte("stale")
+
+	client.invalidateConnectionState()
+
+	client.mu.Lock()
+	connToken := client.token
+	refreshRequired := client.refreshRequired
+	client.mu.Unlock()
+	if connToken != "" {
+		t.Fatalf("connection token must be cleared, got %q", connToken)
+	}
+	if !refreshRequired {
+		t.Fatal("refreshRequired must be set so a fresh token is fetched on reconnect")
+	}
+	if sub.token != "" || sub.prevData != nil {
+		t.Fatalf("subscription state must be invalidated, got token=%q prevData=%q", sub.token, sub.prevData)
+	}
+}
+
+func TestUnsubscribe2502InvalidatesAndResubscribes(t *testing.T) {
+	server := NewFakeServer(t)
+	client := NewProtobufClient(server.URL(), Config{})
+	t.Cleanup(client.Close)
+
+	// Initial token, no GetToken — so after invalidation the token stays empty
+	// (nothing repopulates it), letting us observe the clear deterministically.
+	sub, err := client.NewSubscription("ch", SubscriptionConfig{Token: "sub-token"})
+	if err != nil {
+		t.Fatalf("new subscription: %v", err)
+	}
+	subscribedCh := make(chan SubscribedEvent, 4)
+	sub.OnSubscribed(func(e SubscribedEvent) { subscribedCh <- e })
+
+	_ = client.Connect()
+	_ = sub.Subscribe()
+	waitCh(t, subscribedCh, "subscribed")
+
+	sub.mu.Lock()
+	sub.prevData = []byte("stale-delta-base")
+	sub.mu.Unlock()
+
+	// Server sends "state invalidated" unsubscribe — sub must re-subscribe.
+	server.UnsubscribePush("ch", unsubscribedStateInvalidated, "state invalidated")
+	waitCh(t, subscribedCh, "resubscribed after 2502")
+
+	sub.mu.Lock()
+	token, prevData := sub.token, sub.prevData
+	sub.mu.Unlock()
+	if token != "" {
+		t.Fatalf("subscription token must be cleared by 2502, got %q", token)
+	}
+	if prevData != nil {
+		t.Fatalf("delta base must be cleared by 2502, got %q", prevData)
+	}
+}
+
+func TestUnsubscribeBelow2500DoesNotInvalidate(t *testing.T) {
+	server := NewFakeServer(t)
+	client := NewProtobufClient(server.URL(), Config{})
+	t.Cleanup(client.Close)
+
+	sub, err := client.NewSubscription("ch", SubscriptionConfig{Token: "sub-token"})
+	if err != nil {
+		t.Fatalf("new subscription: %v", err)
+	}
+	subscribedCh := make(chan SubscribedEvent, 4)
+	unsubscribedCh := make(chan UnsubscribedEvent, 4)
+	sub.OnSubscribed(func(e SubscribedEvent) { subscribedCh <- e })
+	sub.OnUnsubscribed(func(e UnsubscribedEvent) { unsubscribedCh <- e })
+
+	_ = client.Connect()
+	_ = sub.Subscribe()
+	waitCh(t, subscribedCh, "subscribed")
+
+	// A code < 2500 fully unsubscribes (no resubscribe, no invalidation path).
+	server.UnsubscribePush("ch", 2000, "server unsubscribe")
+	ev := waitCh(t, unsubscribedCh, "unsubscribed")
+	if ev.Code != 2000 {
+		t.Fatalf("unexpected unsubscribe code: %d", ev.Code)
+	}
+}

--- a/subscription.go
+++ b/subscription.go
@@ -818,9 +818,42 @@ func (s *Subscription) handleUnsubscribe(unsubscribe *protocol.Unsubscribe) {
 	if unsubscribe.Code < 2500 {
 		s.moveToUnsubscribed(unsubscribe.Code, unsubscribe.Reason)
 	} else {
+		if unsubscribe.Code == unsubscribedStateInvalidated {
+			// State invalidated: drop the subscription token and cached state so
+			// the resubscribe below obtains a fresh token and re-syncs.
+			s.invalidateState()
+		}
 		s.moveToSubscribing(unsubscribe.Code, unsubscribe.Reason)
 		s.resubscribe()
 	}
+}
+
+// invalidateState resets cached subscription state on "state invalidated"
+// (unsubscribe code 2502 or connection disconnect code 3014) so the resubscribe
+// re-syncs: it clears the subscription token (so the next subscribe fetches a
+// fresh one via GetToken), the fossil delta base (a stale base would corrupt
+// decoding of the first publication after resubscribe), and the channel-
+// compaction ID mapping. The recovery position is reset to a sentinel epoch the
+// server can never match (offset 0); the recover flag is left untouched. So for
+// a recoverable subscription the resubscribe reply reports WasRecovering=true,
+// Recovered=false — letting the app reload via its existing recovery-failure
+// path rather than looking like a brand-new first subscribe — while a non-
+// recoverable subscription simply resubscribes (the sentinel is not sent). The
+// real epoch/offset are adopted from the subscribe reply.
+//
+// TODO: when map / shared-poll subscription types are added (as in centrifuge-js),
+// reset their cached buffers and restart them from scratch here instead.
+func (s *Subscription) invalidateState() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.pushID != 0 {
+		s.centrifuge.updateSubscriptionPushID(s, s.pushID, 0)
+		s.pushID = 0
+	}
+	s.token = ""
+	s.offset = 0
+	s.epoch = stateInvalidatedEpoch
+	s.prevData = nil
 }
 
 func (s *Subscription) resubscribe() {


### PR DESCRIPTION
Handles server "state invalidated" signals so clients drop stale cached state and re-sync:

- **Unsubscribe code 2502** (per-subscription): clears the subscription token and cached state, then resubscribes.
- **Disconnect code 3014** (connection-wide): clears the connection token (forcing a fresh one via `GetToken`), invalidates every subscription, and reconnects. Handled from **both** the Disconnect push and the WebSocket close frame.

`invalidateState` clears the token, fossil delta base and channel-compaction id, and resets the recovery position to a sentinel epoch (`"_"`, offset 0) the server can never match — leaving the `recover` flag untouched. So a recoverable subscription resubscribes with `was_recovering=true, recovered=false` (the app reloads via its existing recovery-failure path rather than looking like a brand-new first subscribe), while a non-recoverable one just resubscribes. The real epoch/offset are adopted from the subscribe reply.

Tests in `state_invalidation_test.go` (race-clean): `invalidateState`/`invalidateConnectionState` units, 2502 resubscribe, sub-below-2500 still terminal.
