### PR TITLE
Dictionary compression support

### DIFF
--- a/client.go
+++ b/client.go
@@ -1356,10 +1356,9 @@ func (c *Client) startReconnecting() error {
 		if c.events != nil && c.events.onConnected != nil {
 			handler := c.events.onConnected
 			ev := ConnectedEvent{
-				ClientID:              res.Client,
-				Version:               res.Version,
-				Data:                  res.Data,
-				DictionaryCompression: res.Flag&connectionFlagDictionaryCompression != 0,
+				ClientID: res.Client,
+				Version:  res.Version,
+				Data:     res.Data,
 			}
 			c.runHandlerSync(func() {
 				handler(ev)
@@ -1712,7 +1711,8 @@ func (c *Client) sendConnect(fn func(*protocol.ConnectResult, error)) error {
 
 // DictionaryCompressionStats returns what this connection measured. It is zero
 // valued when the transport does not support dictionary compression or the
-// server never enabled it.
+// server never enabled it, so Active also answers "did the server turn this on"
+// - including from inside an OnConnected handler.
 func (c *Client) DictionaryCompressionStats() DictionaryCompressionStats {
 	c.mu.RLock()
 	t := c.transport

--- a/client.go
+++ b/client.go
@@ -36,16 +36,19 @@ const (
 // Close method to clean up state when you don't need client instance
 // anymore.
 type Client struct {
-	futureID       uint64
-	cmdID          uint32
-	mu             sync.RWMutex
-	endpoints      []string
-	round          int
-	protocolType   protocol.Type
-	config         Config
-	token          string
-	data           protocol.Raw
-	transport      transport
+	futureID     uint64
+	cmdID        uint32
+	mu           sync.RWMutex
+	endpoints    []string
+	round        int
+	protocolType protocol.Type
+	config       Config
+	token        string
+	data         protocol.Raw
+	transport    transport
+	// dictionaries survives reconnects, so the structure dictionary is fetched
+	// once per client rather than once per connection.
+	dictionaries   *dictionaryCache
 	disconnectedCh chan struct{}
 	state          State
 	subs           map[string]*Subscription
@@ -210,6 +213,7 @@ func newClient(endpoint string, isProtobuf bool, config Config) *Client {
 		data:              config.Data,
 		logCh:             make(chan LogEntry, 256),
 		logCloseCh:        make(chan struct{}),
+		dictionaries:      newDictionaryCache(),
 	}
 
 	// Queue to run callbacks on.
@@ -1154,7 +1158,7 @@ func (c *Client) startReconnecting() error {
 	if c.logLevelEnabled(LogLevelDebug) {
 		c.log(LogLevelDebug, "creating new transport", nil)
 	}
-	t, err := newWebsocketTransport(u, c.protocolType, wsConfig)
+	t, err := newWebsocketTransport(u, c.protocolType, wsConfig, c.dictionaries)
 	if err != nil {
 		if c.logLevelEnabled(LogLevelDebug) {
 			c.log(LogLevelDebug, "error creating new transport", map[string]string{
@@ -1352,9 +1356,10 @@ func (c *Client) startReconnecting() error {
 		if c.events != nil && c.events.onConnected != nil {
 			handler := c.events.onConnected
 			ev := ConnectedEvent{
-				ClientID: res.Client,
-				Version:  res.Version,
-				Data:     res.Data,
+				ClientID:              res.Client,
+				Version:               res.Version,
+				Data:                  res.Data,
+				DictionaryCompression: res.Flag&connectionFlagDictionaryCompression != 0,
 			}
 			c.runHandlerSync(func() {
 				handler(ev)
@@ -1666,6 +1671,16 @@ func (c *Client) sendConnect(fn func(*protocol.ConnectResult, error)) error {
 	req.Name = c.config.Name
 	req.Version = c.config.Version
 	req.Data = c.data
+	// Always advertise every connection-level codec this SDK can decode. There is
+	// no user-facing option on purpose: the client states capability, the server
+	// decides what to use, and a server which supports none of them ignores it.
+	req.Flag = supportedConnectionFlags
+	// Dictionaries kept from earlier connections. The server answers with an id
+	// alone for anything it recognises, so a returning client is compressed from
+	// its first frame without paying for the transfer again.
+	if ids := c.dictionaries.ids(); len(ids) > 0 {
+		req.State = &protocol.ClientState{DictionaryIds: ids}
+	}
 
 	if len(c.serverSubs) > 0 {
 		subs := make(map[string]*protocol.SubscribeRequest)
@@ -1694,6 +1709,19 @@ func (c *Client) sendConnect(fn func(*protocol.ConnectResult, error)) error {
 		}
 		fn(reply.Connect, nil)
 	})
+}
+
+// CompressionStats returns what this connection measured about dictionary
+// compression. It is zero valued when the transport does not support it or the
+// server never enabled it.
+func (c *Client) CompressionStats() CompressionStats {
+	c.mu.RLock()
+	t := c.transport
+	c.mu.RUnlock()
+	if wt, ok := t.(*websocketTransport); ok {
+		return wt.compressionStats()
+	}
+	return CompressionStats{}
 }
 
 type StreamPosition struct {

--- a/client.go
+++ b/client.go
@@ -1343,6 +1343,9 @@ func (c *Client) startReconnecting() error {
 			})
 		}
 		c.state = StateConnected
+		if wt, ok := t.(*websocketTransport); ok {
+			wt.accepted.Store(res.Flag&connectionFlagDictionaryCompression != 0)
+		}
 
 		if res.Expires {
 			c.refreshTimer = time.AfterFunc(time.Duration(res.Ttl)*time.Second, c.sendRefresh)
@@ -1711,8 +1714,7 @@ func (c *Client) sendConnect(fn func(*protocol.ConnectResult, error)) error {
 
 // DictionaryCompressionStats returns what this connection measured. It is zero
 // valued when the transport does not support dictionary compression or the
-// server never enabled it, so Active also answers "did the server turn this on"
-// - including from inside an OnConnected handler.
+// server never enabled it.
 func (c *Client) DictionaryCompressionStats() DictionaryCompressionStats {
 	c.mu.RLock()
 	t := c.transport

--- a/client.go
+++ b/client.go
@@ -1678,9 +1678,8 @@ func (c *Client) sendConnect(fn func(*protocol.ConnectResult, error)) error {
 	// Dictionaries kept from earlier connections. The server answers with an id
 	// alone for anything it recognises, so a returning client is compressed from
 	// its first frame without paying for the transfer again.
-	if ids := c.dictionaries.ids(); len(ids) > 0 {
-		req.State = &protocol.ClientState{DictionaryIds: ids}
-	}
+	req.Dict = c.dictionaries.advertise()
+	req.Profile = c.config.Profile
 
 	if len(c.serverSubs) > 0 {
 		subs := make(map[string]*protocol.SubscribeRequest)

--- a/client.go
+++ b/client.go
@@ -1710,17 +1710,17 @@ func (c *Client) sendConnect(fn func(*protocol.ConnectResult, error)) error {
 	})
 }
 
-// CompressionStats returns what this connection measured about dictionary
-// compression. It is zero valued when the transport does not support it or the
+// DictionaryCompressionStats returns what this connection measured. It is zero
+// valued when the transport does not support dictionary compression or the
 // server never enabled it.
-func (c *Client) CompressionStats() CompressionStats {
+func (c *Client) DictionaryCompressionStats() DictionaryCompressionStats {
 	c.mu.RLock()
 	t := c.transport
 	c.mu.RUnlock()
 	if wt, ok := t.(*websocketTransport); ok {
-		return wt.compressionStats()
+		return wt.dictionaryCompressionStats()
 	}
-	return CompressionStats{}
+	return DictionaryCompressionStats{}
 }
 
 type StreamPosition struct {

--- a/client.go
+++ b/client.go
@@ -46,9 +46,10 @@ type Client struct {
 	token        string
 	data         protocol.Raw
 	transport    transport
-	// dictionaries survives reconnects, so the structure dictionary is fetched
-	// once per client rather than once per connection.
-	dictionaries   *dictionaryCache
+	// dictionary survives reconnects, so a returning connection costs an id
+	// rather than a transfer. One entry: a client holds the latest dictionary,
+	// not a set of them.
+	dictionary     *dictionaryCache
 	disconnectedCh chan struct{}
 	state          State
 	subs           map[string]*Subscription
@@ -213,7 +214,7 @@ func newClient(endpoint string, isProtobuf bool, config Config) *Client {
 		data:              config.Data,
 		logCh:             make(chan LogEntry, 256),
 		logCloseCh:        make(chan struct{}),
-		dictionaries:      newDictionaryCache(),
+		dictionary:        newDictionaryCache(),
 	}
 
 	// Queue to run callbacks on.
@@ -1158,7 +1159,7 @@ func (c *Client) startReconnecting() error {
 	if c.logLevelEnabled(LogLevelDebug) {
 		c.log(LogLevelDebug, "creating new transport", nil)
 	}
-	t, err := newWebsocketTransport(u, c.protocolType, wsConfig, c.dictionaries)
+	t, err := newWebsocketTransport(u, c.protocolType, wsConfig, c.dictionary)
 	if err != nil {
 		if c.logLevelEnabled(LogLevelDebug) {
 			c.log(LogLevelDebug, "error creating new transport", map[string]string{
@@ -1680,7 +1681,7 @@ func (c *Client) sendConnect(fn func(*protocol.ConnectResult, error)) error {
 	// Dictionaries kept from earlier connections. The server answers with an id
 	// alone for anything it recognises, so a returning client is compressed from
 	// its first frame without paying for the transfer again.
-	req.Dict = c.dictionaries.advertise()
+	req.Dict = c.dictionary.advertise()
 	req.Profile = c.config.Profile
 
 	if len(c.serverSubs) > 0 {

--- a/client_events.go
+++ b/client_events.go
@@ -215,8 +215,15 @@ func (c *Client) OnLeave(handler ServerLeaveHandler) {
 // Frames received before compression was activated are not counted at all, so
 // this reports the steady state rather than the whole connection.
 type DictionaryCompressionStats struct {
+	// Accepted reports whether the server enabled dictionary compression for this
+	// connection. The SDK always advertises support and the server decides, so
+	// this is how to tell whether it was taken up - and it is true as soon as the
+	// connect reply is read, including inside an OnConnected handler.
+	Accepted bool
 	// Active reports whether the connection is currently decoding compressed
-	// frames.
+	// frames. It lags Accepted by one frame: the connect reply that carries the
+	// dictionary is itself uncompressed, so decoding starts with the frame after
+	// it.
 	Active bool
 	// Frames is how many compressed frames were received.
 	Frames int64

--- a/client_events.go
+++ b/client_events.go
@@ -60,11 +60,6 @@ type ConnectedEvent struct {
 	ClientID string
 	Version  string
 	Data     []byte
-	// DictionaryCompression reports whether the server enabled dictionary
-	// compression for this connection. The SDK always advertises support, but the
-	// server decides, so this is the only way to tell whether it is actually in
-	// use - handy when checking that a bandwidth optimisation is live.
-	DictionaryCompression bool
 }
 
 // ConnectingEvent is a connecting event context passed to OnConnecting callback.

--- a/client_events.go
+++ b/client_events.go
@@ -60,6 +60,11 @@ type ConnectedEvent struct {
 	ClientID string
 	Version  string
 	Data     []byte
+	// DictionaryCompression reports whether the server enabled dictionary
+	// compression for this connection. The SDK always advertises support, but the
+	// server decides, so this is the only way to tell whether it is actually in
+	// use - handy when checking that a bandwidth optimisation is live.
+	DictionaryCompression bool
 }
 
 // ConnectingEvent is a connecting event context passed to OnConnecting callback.
@@ -196,4 +201,57 @@ func (c *Client) OnJoin(handler ServerJoinHandler) {
 // OnLeave sets function to handle Leave event from server-side subscriptions.
 func (c *Client) OnLeave(handler ServerLeaveHandler) {
 	c.events.onServerLeave = handler
+}
+
+// CompressionStats reports what a connection measured about dictionary
+// compression on the frames it received.
+//
+// The byte counts are exact at the protocol frame level: BytesReceived is what
+// arrived in compressed WebSocket messages, BytesDecompressed is what those
+// frames expanded to. Two caveats when reading them as a network saving:
+//
+//   - They compare against sending the same frames uncompressed, not against
+//     permessage-deflate, which is the alternative most deployments would
+//     otherwise be using.
+//   - They are measured on WebSocket message payloads, so they exclude WebSocket
+//     and TCP framing. Compression shrinks those slightly too, which makes the
+//     figure a small underestimate of bytes actually taken off the wire.
+//
+// Frames received before compression was activated are not counted at all, so
+// this reports the steady state rather than the whole connection.
+type CompressionStats struct {
+	// Active reports whether the connection is currently decoding compressed
+	// frames.
+	Active bool
+	// Frames is how many compressed frames were received.
+	Frames int64
+	// BytesReceived is the compressed size of those frames.
+	BytesReceived int64
+	// BytesDecompressed is what they expanded to.
+	BytesDecompressed int64
+	// DictionaryID names the dictionary in use. The built-in protocol structure
+	// dictionary reports protocol.BuiltinDictionaryID; a dictionary learned from a
+	// channel's traffic reports a content hash. Distinguishing them matters: the
+	// first is free and immediate, the second has to be earned and transferred.
+	DictionaryID string
+
+	// DictionaryBytes is what the dictionary itself cost to receive. It is a real
+	// cost of the feature, so BytesSaved subtracts it.
+	DictionaryBytes int64
+}
+
+// BytesSaved is the net saving: what these frames would have cost uncompressed,
+// less what they actually cost, less the dictionary transfer. It can be negative
+// on a connection that received too little traffic to earn the dictionary back.
+func (s CompressionStats) BytesSaved() int64 {
+	return s.BytesDecompressed - s.BytesReceived - s.DictionaryBytes
+}
+
+// Ratio is uncompressed over compressed for the frames received, ignoring the
+// dictionary transfer. Zero when nothing was received.
+func (s CompressionStats) Ratio() float64 {
+	if s.BytesReceived == 0 {
+		return 0
+	}
+	return float64(s.BytesDecompressed) / float64(s.BytesReceived)
 }

--- a/client_events.go
+++ b/client_events.go
@@ -229,10 +229,9 @@ type CompressionStats struct {
 	BytesReceived int64
 	// BytesDecompressed is what they expanded to.
 	BytesDecompressed int64
-	// DictionaryID names the dictionary in use. The built-in protocol structure
-	// dictionary reports protocol.BuiltinDictionaryID; a dictionary learned from a
-	// channel's traffic reports a content hash. Distinguishing them matters: the
-	// first is free and immediate, the second has to be earned and transferred.
+	// DictionaryID names the dictionary in use. It is a hash of the dictionary
+	// content, so the same id always means the same bytes - which is what makes
+	// it safe to cache one across connections.
 	DictionaryID string
 
 	// DictionaryBytes is what the dictionary itself cost to receive. It is a real

--- a/client_events.go
+++ b/client_events.go
@@ -203,8 +203,8 @@ func (c *Client) OnLeave(handler ServerLeaveHandler) {
 	c.events.onServerLeave = handler
 }
 
-// CompressionStats reports what a connection measured about dictionary
-// compression on the frames it received.
+// DictionaryCompressionStats reports what a connection measured on the frames
+// it decoded against a dictionary.
 //
 // The byte counts are exact at the protocol frame level: BytesReceived is what
 // arrived in compressed WebSocket messages, BytesDecompressed is what those
@@ -219,7 +219,7 @@ func (c *Client) OnLeave(handler ServerLeaveHandler) {
 //
 // Frames received before compression was activated are not counted at all, so
 // this reports the steady state rather than the whole connection.
-type CompressionStats struct {
+type DictionaryCompressionStats struct {
 	// Active reports whether the connection is currently decoding compressed
 	// frames.
 	Active bool
@@ -242,13 +242,13 @@ type CompressionStats struct {
 // BytesSaved is the net saving: what these frames would have cost uncompressed,
 // less what they actually cost, less the dictionary transfer. It can be negative
 // on a connection that received too little traffic to earn the dictionary back.
-func (s CompressionStats) BytesSaved() int64 {
+func (s DictionaryCompressionStats) BytesSaved() int64 {
 	return s.BytesDecompressed - s.BytesReceived - s.DictionaryBytes
 }
 
 // Ratio is uncompressed over compressed for the frames received, ignoring the
 // dictionary transfer. Zero when nothing was received.
-func (s CompressionStats) Ratio() float64 {
+func (s DictionaryCompressionStats) Ratio() float64 {
 	if s.BytesReceived == 0 {
 		return 0
 	}

--- a/config.go
+++ b/config.go
@@ -31,6 +31,14 @@ type Config struct {
 	// Version allows setting client version. This is an application
 	// specific information. By default, no version set.
 	Version string
+	// Profile names the application context this connection belongs to, such as
+	// "trading-dashboard" or "mobile-feed". A server may use it to serve a
+	// compression dictionary built for connections of that kind.
+	//
+	// It describes the client, not the user: use a small fixed set of names, the
+	// same way as Name. The server decides what to do with it and may ignore or
+	// override it, so it must never be relied on to gate anything.
+	Profile string
 	// Proxy specifies a function to return a proxy for a given Request.
 	// If the function returns a non-nil error, the request is aborted with the
 	// provided error. If function returns a nil *URL, no proxy is used.

--- a/dictionary_cache.go
+++ b/dictionary_cache.go
@@ -1,0 +1,68 @@
+package centrifuge
+
+import "sync"
+
+// dictionaryCache remembers the structure dictionary across a client's
+// connections, so a reconnect costs an id rather than a transfer.
+//
+// Only the structure dictionary is kept, and only the most recent one. Its id
+// changes only when a server is upgraded or an operator edits it, so a single
+// entry matches on essentially every reconnect. The exception is the window of a
+// rolling deploy, where old and new nodes disagree: a client hopping between
+// them re-downloads once per hop. That costs about 1.6 KB, is bounded by the
+// length of the deploy, and needs no eviction policy to get right.
+//
+// Channel dictionaries are deliberately not cached. They are built per node from
+// a channel's own traffic, so a cached copy would rarely match, and they contain
+// verbatim fragments of other users' messages - worth holding for the life of a
+// connection, not beyond it.
+//
+// The entry is keyed by id, which is a hash of the content, so it can never be
+// returned for a dictionary whose bytes differ.
+type dictionaryCache struct {
+	mu   sync.Mutex
+	id   string
+	dict []byte
+}
+
+func newDictionaryCache() *dictionaryCache { return &dictionaryCache{} }
+
+func (c *dictionaryCache) get(id string) ([]byte, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if id == "" || id != c.id {
+		return nil, false
+	}
+	return c.dict, true
+}
+
+func (c *dictionaryCache) put(id string, dict []byte) {
+	if id == "" || len(dict) == 0 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.id, c.dict = id, dict
+}
+
+// ids returns what this client holds, to advertise at connect. The protocol
+// allows several so a client may keep more; this one keeps the latest.
+func (c *dictionaryCache) ids() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.id == "" {
+		return nil
+	}
+	return []string{c.id}
+}
+
+// forget drops the entry. It is called when a frame fails to decode while that
+// dictionary is in use: without it a corrupted entry would be advertised again
+// on every reconnect and wedge the client in a loop.
+func (c *dictionaryCache) forget(id string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if id == c.id {
+		c.id, c.dict = "", nil
+	}
+}

--- a/dictionary_cache.go
+++ b/dictionary_cache.go
@@ -2,20 +2,15 @@ package centrifuge
 
 import "sync"
 
-// dictionaryCache remembers the structure dictionary across a client's
-// connections, so a reconnect costs an id rather than a transfer.
+// dictionaryCache remembers the dictionary the server sent in the connect reply,
+// so a reconnect costs an id rather than a transfer.
 //
-// Only the structure dictionary is kept, and only the most recent one. Its id
-// changes only when a server is upgraded or an operator edits it, so a single
-// entry matches on essentially every reconnect. The exception is the window of a
-// rolling deploy, where old and new nodes disagree: a client hopping between
-// them re-downloads once per hop. That costs about 1.6 KB, is bounded by the
-// length of the deploy, and needs no eviction policy to get right.
-//
-// Channel dictionaries are deliberately not cached. They are built per node from
-// a channel's own traffic, so a cached copy would rarely match, and they contain
-// verbatim fragments of other users' messages - worth holding for the life of a
-// connection, not beyond it.
+// One entry, the most recent. A dictionary belongs to a profile and changes only
+// when the server publishes a new version, so a single entry matches on
+// essentially every reconnect. The exception is the window of a rolling deploy,
+// where old and new nodes disagree: a client hopping between them re-downloads
+// once per hop. That is bounded by the length of the deploy and needs no
+// eviction policy to get right.
 //
 // The entry is keyed by id, which is a hash of the content, so it can never be
 // returned for a dictionary whose bytes differ.
@@ -45,15 +40,11 @@ func (c *dictionaryCache) put(id string, dict []byte) {
 	c.id, c.dict = id, dict
 }
 
-// ids returns what this client holds, to advertise at connect. The protocol
-// allows several so a client may keep more; this one keeps the latest.
-func (c *dictionaryCache) ids() []string {
+// id returns what this client holds, to advertise at connect.
+func (c *dictionaryCache) advertise() string {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.id == "" {
-		return nil
-	}
-	return []string{c.id}
+	return c.id
 }
 
 // forget drops the entry. It is called when a frame fails to decode while that

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/centrifugal/centrifuge-go
 go 1.25.0
 
 require (
-	github.com/centrifugal/protocol v0.19.2
+	github.com/centrifugal/protocol v0.20.1-0.20260811164823-815457ed4d09
 	github.com/gorilla/websocket v1.5.3
 	github.com/jpillora/backoff v1.0.0
 	github.com/shadowspore/fossil-delta v0.0.0-20241213113458-1d797d70cbe3
@@ -19,5 +19,3 @@ require (
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect
 )
-
-replace github.com/centrifugal/protocol => ../protocol

--- a/go.mod
+++ b/go.mod
@@ -19,3 +19,5 @@ require (
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect
 )
+
+replace github.com/centrifugal/protocol => ../protocol

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/centrifugal/protocol v0.20.1-0.20260811164823-815457ed4d09 h1:8SJBvmcS/KXNu8h/79VyYgey4WNreVM9NR3NrGNLFSQ=
+github.com/centrifugal/protocol v0.20.1-0.20260811164823-815457ed4d09/go.mod h1:3pinAfcb+bH8Yp8Ewhf9QTRTzsQ9veP/QOrCk5D5SSE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/centrifugal/protocol v0.19.2 h1:wc1S75EJvX5/KczsqEG74Bt/Jw/XwECDUzWR/vE/E9U=
-github.com/centrifugal/protocol v0.19.2/go.mod h1:zFsp4f1ZRejq1dkyNUbabdPj4dMYOpK8RRXDwHGVpVY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/protocol.go
+++ b/protocol.go
@@ -88,3 +88,13 @@ func pubFromProto(pub *protocol.Publication) Publication {
 	}
 	return p
 }
+
+// connectionFlagDictionaryCompression advertises in ConnectRequest.Flag that
+// this client understands ConnectionState pushes carrying a dictionary and can
+// decode DEFLATE-compressed frames against it. Must match the server side: the
+// flag identifies the codec, since frames themselves carry only a
+// compressed/raw marker.
+const connectionFlagDictionaryCompression int64 = 1 << 0
+
+// supportedConnectionFlags is what this SDK advertises at connect.
+const supportedConnectionFlags = connectionFlagDictionaryCompression

--- a/transport_websocket.go
+++ b/transport_websocket.go
@@ -87,7 +87,10 @@ type websocketTransport struct {
 	compressedIn   atomic.Int64
 	uncompressedIn atomic.Int64
 	dictionaryIn   atomic.Int64
-	framesIn       atomic.Int64
+	// dictWireBytes is the encoded size of the dictionary as it arrived, set
+	// while decoding it and read once by the frame that carried it.
+	dictWireBytes int64
+	framesIn      atomic.Int64
 }
 
 // compressionStats returns what this connection measured about compression.
@@ -147,15 +150,23 @@ func (t *websocketTransport) dictionaryFrom(d *protocol.Dictionary, cacheable bo
 	// Protobuf connections carry the dictionary as raw bytes; JSON connections
 	// have to base64 it, because a bytes field carries raw JSON in that protocol.
 	// Exactly one is set, so prefer the cheap one and fall back.
+	//
+	// dictWireBytes is measured here, on the encoded form, because that is what
+	// actually crossed the wire: the content is deflated, and on JSON it is
+	// base64 on top of that. Charging the inflated size instead - which is what
+	// the codec holds - overstated the cost of the structure dictionary by most
+	// of its size, and did so in the operator's dashboards as well as the SDK's.
 	var raw []byte
 	if len(d.Data) > 0 {
 		raw = d.Data
+		t.dictWireBytes = int64(len(d.Data))
 	} else {
 		decoded, err := base64.StdEncoding.DecodeString(d.DataB64)
 		if err != nil || len(decoded) == 0 {
 			return nil
 		}
 		raw = decoded
+		t.dictWireBytes = int64(len(d.DataB64))
 	}
 	// Content is always deflated: the frame carrying it cannot be compressed,
 	// because nothing is installed yet to compress it against.
@@ -331,7 +342,7 @@ func (t *websocketTransport) reader() {
 					// connection, so it is recorded and later subtracted from bytes
 					// saved. One reused from the cache crossed no wire and is not.
 					if !t.fromCache {
-						t.dictionaryIn.Add(int64(len(c.Dict())))
+						t.dictionaryIn.Add(t.dictWireBytes)
 					}
 				} else if t.unusableDict {
 					// The server named a dictionary this client does not hold, so

--- a/transport_websocket.go
+++ b/transport_websocket.go
@@ -344,6 +344,15 @@ func (t *websocketTransport) reader() {
 					if !t.fromCache {
 						t.dictionaryIn.Add(t.dictWireBytes)
 					}
+				} else if reply.Connect != nil &&
+					reply.Connect.Flag&connectionFlagDictionaryCompression == 0 {
+					// A codec installed from cache before connecting, on a
+					// connection the server then declined to compress. It marks
+					// this reply so it could be read, and nothing after it - so
+					// keeping the codec would mean stripping a marker off frames
+					// that do not have one.
+					t.codec = nil
+					t.pendingCodec = nil
 				} else if t.unusableDict {
 					// The server named a dictionary this client does not hold, so
 					// nothing after this frame can be decoded. Forget the id and

--- a/transport_websocket.go
+++ b/transport_websocket.go
@@ -65,10 +65,14 @@ type websocketTransport struct {
 	// codec decodes frames once the server activated dictionary compression.
 	// pendingCodec holds a dictionary seen inside the frame currently being
 	// decoded; it is promoted only after that frame is fully consumed, because
-	// the frame carrying a dictionary is itself sent uncompressed. Both are
-	// touched only by the reader goroutine.
-	codec        *protocol.DeflateFrameCodec
-	pendingCodec *protocol.DeflateFrameCodec
+	// the frame carrying a dictionary is itself sent uncompressed.
+	//
+	// Both are written by the reader goroutine and read by callers of
+	// Client.DictionaryCompressionStats, so both are atomic - the counters
+	// beneath were already, and these were the same shared state wearing a
+	// plain pointer.
+	codec        atomic.Pointer[protocol.DeflateFrameCodec]
+	pendingCodec atomic.Pointer[protocol.DeflateFrameCodec]
 	// cache remembers the structure dictionary across this client's connections,
 	// so a reconnect costs an id rather than a transfer. It is shared with the
 	// Client and touched only by the reader goroutine plus connect setup.
@@ -93,14 +97,23 @@ type websocketTransport struct {
 	framesIn      atomic.Int64
 }
 
-// compressionStats returns what this connection measured about compression.
+// dictionaryCompressionStats returns what this connection measured.
+//
+// A dictionary counts as active from the moment it is installed, not from the
+// frame it starts decoding: the connect reply that carries it is itself
+// uncompressed, so a caller asking during OnConnected would otherwise be told
+// no while the server had already switched compression on.
 func (t *websocketTransport) dictionaryCompressionStats() DictionaryCompressionStats {
+	codec := t.codec.Load()
+	if codec == nil {
+		codec = t.pendingCodec.Load()
+	}
 	id := ""
-	if t.codec != nil {
-		id = t.codec.ID()
+	if codec != nil {
+		id = codec.ID()
 	}
 	return DictionaryCompressionStats{
-		Active:            t.codec != nil,
+		Active:            codec != nil,
 		DictionaryID:      id,
 		Frames:            t.framesIn.Load(),
 		BytesReceived:     t.compressedIn.Load(),
@@ -279,9 +292,9 @@ func (t *websocketTransport) reader() {
 			t.disconnect = disconnect
 			return
 		}
-		if t.codec != nil {
+		if codec := t.codec.Load(); codec != nil {
 			compressedLen := len(data)
-			data, err = t.codec.Decompress(nil, data, maxDecompressedFrameSize)
+			data, err = codec.Decompress(nil, data, maxDecompressedFrameSize)
 			if err != nil {
 				// A cached dictionary that cannot decode is a stale or corrupted
 				// entry: drop it and retry, or the client would advertise it again
@@ -289,7 +302,7 @@ func (t *websocketTransport) reader() {
 				// protocol error and is not worth retrying.
 				retry := false
 				if t.fromCache && t.cache != nil {
-					t.cache.forget(t.codec.ID())
+					t.cache.forget(codec.ID())
 					retry = true
 				}
 				t.disconnect = &disconnect{Code: disconnectBadProtocol, Reason: "frame decode error", Reconnect: retry}
@@ -318,7 +331,7 @@ func (t *websocketTransport) reader() {
 				offered := offeredDictionary(reply)
 				if c := t.dictionaryFrom(offered); c != nil {
 					// Applied after this frame completes - see pendingCodec.
-					t.pendingCodec = c
+					t.pendingCodec.Store(c)
 					// A dictionary that had to be sent is a real cost paid on this
 					// connection, so it is recorded and later subtracted from bytes
 					// saved. One reused from the cache crossed no wire and is not.
@@ -347,9 +360,8 @@ func (t *websocketTransport) reader() {
 				}
 			}
 		}
-		if t.pendingCodec != nil {
-			t.codec = t.pendingCodec
-			t.pendingCodec = nil
+		if pending := t.pendingCodec.Swap(nil); pending != nil {
+			t.codec.Store(pending)
 		}
 	}
 }

--- a/transport_websocket.go
+++ b/transport_websocket.go
@@ -3,6 +3,7 @@ package centrifuge
 import (
 	"context"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -10,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/centrifugal/protocol"
@@ -59,6 +61,123 @@ type websocketTransport struct {
 	disconnect     *disconnect
 	closed         bool
 	closeCh        chan struct{}
+
+	// codec decodes frames once the server activated dictionary compression.
+	// pendingCodec holds a dictionary seen inside the frame currently being
+	// decoded; it is promoted only after that frame is fully consumed, because
+	// the frame carrying a dictionary is itself sent uncompressed. Both are
+	// touched only by the reader goroutine.
+	codec        *protocol.DeflateFrameCodec
+	pendingCodec *protocol.DeflateFrameCodec
+	// cache remembers the structure dictionary across this client's connections,
+	// so a reconnect costs an id rather than a transfer. It is shared with the
+	// Client and touched only by the reader goroutine plus connect setup.
+	cache *dictionaryCache
+	// structureCandidate marks the next dictionary as the structure one - it is
+	// always the first a connection receives - so channel dictionaries that follow
+	// are not cached.
+	structureCandidate bool
+	// fromCache records that the codec in use came from the cache, so a decode
+	// failure can be attributed to a stale entry and retried rather than treated
+	// as an unrecoverable protocol error.
+	fromCache bool
+	// unusableDict is set when the server named a dictionary this client does not
+	// have. Nothing after that frame can be decoded, so the connection has to be
+	// restarted rather than left to misread everything.
+	unusableDict bool
+
+	// Compression accounting. Written by the reader goroutine, read by callers
+	// of Client.CompressionStats, hence atomics.
+	compressedIn   atomic.Int64
+	uncompressedIn atomic.Int64
+	dictionaryIn   atomic.Int64
+	framesIn       atomic.Int64
+}
+
+// compressionStats returns what this connection measured about compression.
+func (t *websocketTransport) compressionStats() CompressionStats {
+	id := ""
+	if t.codec != nil {
+		id = t.codec.ID()
+	}
+	return CompressionStats{
+		Active:            t.codec != nil,
+		DictionaryID:      id,
+		Frames:            t.framesIn.Load(),
+		BytesReceived:     t.compressedIn.Load(),
+		BytesDecompressed: t.uncompressedIn.Load(),
+		DictionaryBytes:   t.dictionaryIn.Load(),
+	}
+}
+
+// maxDecompressedFrameSize bounds a frame after decompression so that a small
+// crafted frame can not be inflated into an unbounded allocation.
+const maxDecompressedFrameSize = 16 * 1024 * 1024
+
+// maxDictionarySize bounds a dictionary after inflation, for the same reason.
+// Useful dictionaries are a few kilobytes; this leaves generous headroom.
+const maxDictionarySize = 1 * 1024 * 1024
+
+// dictionaryFromPush builds a codec from a ConnectionState push carrying a
+// dictionary, returning nil when the push carries something else. Unknown
+// ConnectionState fields are ignored on purpose: the frame is meant to carry
+// further connection-level state in future without breaking older clients.
+//
+// A dictionary with an id but no content means "use the one you already have" -
+// the server recognised an id this client advertised at connect, so there was
+// nothing to send. An id is a hash of the content, so a match is byte identical
+// by construction.
+func (t *websocketTransport) dictionaryFromPush(push *protocol.Push) *protocol.DeflateFrameCodec {
+	if push == nil || push.State == nil || push.State.Dictionary == nil {
+		return nil
+	}
+	d := push.State.Dictionary
+	if len(d.Data) == 0 && d.DataB64 == "" {
+		if t.cache != nil {
+			if dict, ok := t.cache.get(d.Id); ok {
+				t.fromCache = true
+				return protocol.NewDeflateFrameCodec(d.Id, dict)
+			}
+		}
+		// The server named something this client does not have - it was evicted
+		// between advertising it and now, or the server is confused. Either way
+		// nothing after this frame can be decoded.
+		t.unusableDict = true
+		return nil
+	}
+	// Protobuf connections carry the dictionary as raw bytes; JSON connections
+	// have to base64 it, because a bytes field carries raw JSON in that protocol.
+	// Exactly one is set, so prefer the cheap one and fall back.
+	var raw []byte
+	if len(d.Data) > 0 {
+		raw = d.Data
+	} else {
+		decoded, err := base64.StdEncoding.DecodeString(d.DataB64)
+		if err != nil || len(decoded) == 0 {
+			return nil
+		}
+		raw = decoded
+	}
+	if d.Flags&protocol.DictionaryFlagDeflate != 0 {
+		// The first dictionary of a connection travels deflated: its delivery
+		// frame could not be compressed, because nothing was installed yet to
+		// compress it against.
+		inflated, err := protocol.InflateDictionary(raw, maxDictionarySize)
+		if err != nil {
+			return nil
+		}
+		raw = inflated
+	}
+	// Only the structure dictionary is remembered. A channel dictionary is built
+	// per node from that channel's traffic, so a cached copy would rarely match
+	// on reconnect, and it holds verbatim fragments of other users' messages -
+	// worth keeping for the life of a connection, not beyond it.
+	if t.cache != nil && d.Id != "" && t.structureCandidate {
+		t.cache.put(d.Id, raw)
+	}
+	t.structureCandidate = false
+	t.fromCache = false
+	return protocol.NewDeflateFrameCodec(d.Id, raw)
 }
 
 // websocketConfig configures Websocket transport.
@@ -95,7 +214,7 @@ type websocketConfig struct {
 	Header http.Header
 }
 
-func newWebsocketTransport(url string, protocolType protocol.Type, config websocketConfig) (transport, error) {
+func newWebsocketTransport(url string, protocolType protocol.Type, config websocketConfig, cache *dictionaryCache) (transport, error) {
 	wsHeaders := config.Header
 
 	dialer := &websocket.Dialer{}
@@ -119,6 +238,7 @@ func newWebsocketTransport(url string, protocolType protocol.Type, config websoc
 	if err != nil {
 		return nil, fmt.Errorf("error dial: %v", err)
 	}
+
 	if resp.StatusCode != http.StatusSwitchingProtocols {
 		return nil, fmt.Errorf("wrong status code while connecting to server: %d", resp.StatusCode)
 	}
@@ -130,6 +250,10 @@ func newWebsocketTransport(url string, protocolType protocol.Type, config websoc
 		closeCh:        make(chan struct{}),
 		commandEncoder: newCommandEncoder(protocolType),
 		protocolType:   protocolType,
+		cache:          cache,
+		// The first dictionary a connection receives is always the structure one,
+		// which is the only kind worth remembering.
+		structureCandidate: true,
 	}
 	go t.reader()
 	return t, nil
@@ -158,6 +282,26 @@ func (t *websocketTransport) reader() {
 			t.disconnect = disconnect
 			return
 		}
+		if t.codec != nil {
+			compressedLen := len(data)
+			data, err = t.codec.Decompress(nil, data, maxDecompressedFrameSize)
+			if err != nil {
+				// A cached dictionary that cannot decode is a stale or corrupted
+				// entry: drop it and retry, or the client would advertise it again
+				// on every reconnect and never recover. Anything else is a real
+				// protocol error and is not worth retrying.
+				retry := false
+				if t.fromCache && t.cache != nil {
+					t.cache.forget(t.codec.ID())
+					retry = true
+				}
+				t.disconnect = &disconnect{Code: disconnectBadProtocol, Reason: "frame decode error", Reconnect: retry}
+				return
+			}
+			t.framesIn.Add(1)
+			t.compressedIn.Add(int64(compressedLen))
+			t.uncompressedIn.Add(int64(len(data)))
+		}
 		//println("<----", strings.Trim(string(data), "\n"))
 	loop:
 		for {
@@ -171,6 +315,27 @@ func (t *websocketTransport) reader() {
 					t.disconnect = &disconnect{Code: disconnectBadProtocol, Reason: "decode error", Reconnect: false}
 					return
 				}
+				if c := t.dictionaryFromPush(reply.Push); c != nil {
+					// Applied after this frame completes - see pendingCodec.
+					t.pendingCodec = c
+					// A dictionary that had to be sent is a real cost paid on this
+					// connection, so it is recorded and later subtracted from bytes
+					// saved. One reused from the cache crossed no wire and is not.
+					if !t.fromCache {
+						t.dictionaryIn.Add(int64(len(c.Dict())))
+					}
+				} else if t.unusableDict {
+					// The server named a dictionary this client does not hold, so
+					// nothing after this frame can be decoded. Forget the id and
+					// start over rather than misread everything that follows.
+					t.unusableDict = false
+					if t.cache != nil && reply.Push.State.Dictionary != nil {
+						t.cache.forget(reply.Push.State.Dictionary.Id)
+					}
+					t.disconnect = &disconnect{Code: disconnectBadProtocol,
+						Reason: "unknown dictionary", Reconnect: true}
+					return
+				}
 				select {
 				case <-t.closeCh:
 					return
@@ -180,6 +345,10 @@ func (t *websocketTransport) reader() {
 					// goroutine.
 				}
 			}
+		}
+		if t.pendingCodec != nil {
+			t.codec = t.pendingCodec
+			t.pendingCodec = nil
 		}
 	}
 }

--- a/transport_websocket.go
+++ b/transport_websocket.go
@@ -73,10 +73,6 @@ type websocketTransport struct {
 	// so a reconnect costs an id rather than a transfer. It is shared with the
 	// Client and touched only by the reader goroutine plus connect setup.
 	cache *dictionaryCache
-	// structureCandidate marks the next dictionary as the structure one - it is
-	// always the first a connection receives - so channel dictionaries that follow
-	// are not cached.
-	structureCandidate bool
 	// fromCache records that the codec in use came from the cache, so a decode
 	// failure can be attributed to a stale entry and retried rather than treated
 	// as an unrecoverable protocol error.
@@ -118,20 +114,23 @@ const maxDecompressedFrameSize = 16 * 1024 * 1024
 // Useful dictionaries are a few kilobytes; this leaves generous headroom.
 const maxDictionarySize = 1 * 1024 * 1024
 
-// dictionaryFromPush builds a codec from a ConnectionState push carrying a
-// dictionary, returning nil when the push carries something else. Unknown
-// ConnectionState fields are ignored on purpose: the frame is meant to carry
-// further connection-level state in future without breaking older clients.
+// dictionaryFrom builds a codec from a Dictionary the server sent, returning
+// nil when there is nothing usable in it.
+//
+// cacheable says whether the dictionary is worth keeping past this connection.
+// The one that arrives in the connect reply is: it belongs to this client's
+// profile and changes only when the server publishes a new version, so keeping
+// it turns the next connect into an id and no transfer. One that arrives later
+// in a push is connection-scoped and is not kept.
 //
 // A dictionary with an id but no content means "use the one you already have" -
-// the server recognised an id this client advertised at connect, so there was
+// the server recognised the id this client advertised at connect, so there was
 // nothing to send. An id is a hash of the content, so a match is byte identical
 // by construction.
-func (t *websocketTransport) dictionaryFromPush(push *protocol.Push) *protocol.DeflateFrameCodec {
-	if push == nil || push.State == nil || push.State.Dictionary == nil {
+func (t *websocketTransport) dictionaryFrom(d *protocol.Dictionary, cacheable bool) *protocol.DeflateFrameCodec {
+	if d == nil {
 		return nil
 	}
-	d := push.State.Dictionary
 	if len(d.Data) == 0 && d.DataB64 == "" {
 		if t.cache != nil {
 			if dict, ok := t.cache.get(d.Id); ok {
@@ -158,24 +157,16 @@ func (t *websocketTransport) dictionaryFromPush(push *protocol.Push) *protocol.D
 		}
 		raw = decoded
 	}
-	if d.Flags&protocol.DictionaryFlagDeflate != 0 {
-		// The first dictionary of a connection travels deflated: its delivery
-		// frame could not be compressed, because nothing was installed yet to
-		// compress it against.
-		inflated, err := protocol.InflateDictionary(raw, maxDictionarySize)
-		if err != nil {
-			return nil
-		}
-		raw = inflated
+	// Content is always deflated: the frame carrying it cannot be compressed,
+	// because nothing is installed yet to compress it against.
+	inflated, err := protocol.InflateDictionary(raw, maxDictionarySize)
+	if err != nil {
+		return nil
 	}
-	// Only the structure dictionary is remembered. A channel dictionary is built
-	// per node from that channel's traffic, so a cached copy would rarely match
-	// on reconnect, and it holds verbatim fragments of other users' messages -
-	// worth keeping for the life of a connection, not beyond it.
-	if t.cache != nil && d.Id != "" && t.structureCandidate {
+	raw = inflated
+	if cacheable && t.cache != nil && d.Id != "" {
 		t.cache.put(d.Id, raw)
 	}
-	t.structureCandidate = false
 	t.fromCache = false
 	return protocol.NewDeflateFrameCodec(d.Id, raw)
 }
@@ -251,9 +242,6 @@ func newWebsocketTransport(url string, protocolType protocol.Type, config websoc
 		commandEncoder: newCommandEncoder(protocolType),
 		protocolType:   protocolType,
 		cache:          cache,
-		// The first dictionary a connection receives is always the structure one,
-		// which is the only kind worth remembering.
-		structureCandidate: true,
 	}
 	go t.reader()
 	return t, nil
@@ -315,7 +303,11 @@ func (t *websocketTransport) reader() {
 					t.disconnect = &disconnect{Code: disconnectBadProtocol, Reason: "decode error", Reconnect: false}
 					return
 				}
-				if c := t.dictionaryFromPush(reply.Push); c != nil {
+				// Compression is set up by the connect reply, which is the frame
+				// that carries the dictionary. A push may replace it later, which
+				// the protocol allows but the server does not currently do.
+				offered, cacheable := offeredDictionary(reply)
+				if c := t.dictionaryFrom(offered, cacheable); c != nil {
 					// Applied after this frame completes - see pendingCodec.
 					t.pendingCodec = c
 					// A dictionary that had to be sent is a real cost paid on this
@@ -329,8 +321,8 @@ func (t *websocketTransport) reader() {
 					// nothing after this frame can be decoded. Forget the id and
 					// start over rather than misread everything that follows.
 					t.unusableDict = false
-					if t.cache != nil && reply.Push.State.Dictionary != nil {
-						t.cache.forget(reply.Push.State.Dictionary.Id)
+					if t.cache != nil && offered != nil {
+						t.cache.forget(offered.Id)
 					}
 					t.disconnect = &disconnect{Code: disconnectBadProtocol,
 						Reason: "unknown dictionary", Reconnect: true}
@@ -351,6 +343,20 @@ func (t *websocketTransport) reader() {
 			t.pendingCodec = nil
 		}
 	}
+}
+
+// offeredDictionary returns the dictionary a reply carries, if any, and whether
+// it is worth caching past this connection. Unknown ConnectionState fields are
+// ignored on purpose: the message is meant to carry further connection-level
+// state in future without breaking older clients.
+func offeredDictionary(reply *protocol.Reply) (*protocol.Dictionary, bool) {
+	if reply.Connect != nil && reply.Connect.Dict != nil {
+		return reply.Connect.Dict, true
+	}
+	if reply.Push != nil && reply.Push.State != nil && reply.Push.State.Dict != nil {
+		return reply.Push.State.Dict, false
+	}
+	return nil, false
 }
 
 func (t *websocketTransport) Write(cmd *protocol.Command, timeout time.Duration) error {

--- a/transport_websocket.go
+++ b/transport_websocket.go
@@ -73,6 +73,11 @@ type websocketTransport struct {
 	// plain pointer.
 	codec        atomic.Pointer[protocol.DeflateFrameCodec]
 	pendingCodec atomic.Pointer[protocol.DeflateFrameCodec]
+	// accepted records that the server confirmed dictionary compression in the
+	// connect reply. It answers a different question from codec being set: this
+	// one is known as soon as the reply is read, which is when a caller in an
+	// OnConnected handler asks.
+	accepted atomic.Bool
 	// cache remembers the structure dictionary across this client's connections,
 	// so a reconnect costs an id rather than a transfer. It is shared with the
 	// Client and touched only by the reader goroutine plus connect setup.
@@ -98,11 +103,6 @@ type websocketTransport struct {
 }
 
 // dictionaryCompressionStats returns what this connection measured.
-//
-// A dictionary counts as active from the moment it is installed, not from the
-// frame it starts decoding: the connect reply that carries it is itself
-// uncompressed, so a caller asking during OnConnected would otherwise be told
-// no while the server had already switched compression on.
 func (t *websocketTransport) dictionaryCompressionStats() DictionaryCompressionStats {
 	codec := t.codec.Load()
 	if codec == nil {
@@ -113,6 +113,7 @@ func (t *websocketTransport) dictionaryCompressionStats() DictionaryCompressionS
 		id = codec.ID()
 	}
 	return DictionaryCompressionStats{
+		Accepted:          t.accepted.Load(),
 		Active:            codec != nil,
 		DictionaryID:      id,
 		Frames:            t.framesIn.Load(),

--- a/transport_websocket.go
+++ b/transport_websocket.go
@@ -243,6 +243,23 @@ func newWebsocketTransport(url string, protocolType protocol.Type, config websoc
 		protocolType:   protocolType,
 		cache:          cache,
 	}
+	// Install the codec for whatever this client is about to advertise, before
+	// the connect reply arrives. A server that recognises the id compresses the
+	// connect reply itself - there is nothing to wait for once both sides hold
+	// the dictionary - so learning the codec from a reply would mean never
+	// being able to read the reply that teaches it.
+	//
+	// Safe when the server does not recognise it: every frame carries a codec
+	// marker, so a raw reply passes through untouched and the dictionary it
+	// carries replaces this one.
+	if cache != nil {
+		if held := cache.advertise(); held != "" {
+			if bytes, ok := cache.get(held); ok {
+				t.codec = protocol.NewDeflateFrameCodec(held, bytes)
+				t.fromCache = true
+			}
+		}
+	}
 	go t.reader()
 	return t, nil
 }

--- a/transport_websocket.go
+++ b/transport_websocket.go
@@ -120,17 +120,15 @@ const maxDictionarySize = 1 * 1024 * 1024
 // dictionaryFrom builds a codec from a Dictionary the server sent, returning
 // nil when there is nothing usable in it.
 //
-// cacheable says whether the dictionary is worth keeping past this connection.
-// The one that arrives in the connect reply is: it belongs to this client's
-// profile and changes only when the server publishes a new version, so keeping
-// it turns the next connect into an id and no transfer. One that arrives later
-// in a push is connection-scoped and is not kept.
+// What it builds is always worth keeping past this connection: a dictionary
+// belongs to this client's profile and changes only when the server publishes a
+// new version, so caching it turns the next connect into an id and no transfer.
 //
 // A dictionary with an id but no content means "use the one you already have" -
 // the server recognised the id this client advertised at connect, so there was
 // nothing to send. An id is a hash of the content, so a match is byte identical
 // by construction.
-func (t *websocketTransport) dictionaryFrom(d *protocol.Dictionary, cacheable bool) *protocol.DeflateFrameCodec {
+func (t *websocketTransport) dictionaryFrom(d *protocol.Dictionary) *protocol.DeflateFrameCodec {
 	if d == nil {
 		return nil
 	}
@@ -175,7 +173,7 @@ func (t *websocketTransport) dictionaryFrom(d *protocol.Dictionary, cacheable bo
 		return nil
 	}
 	raw = inflated
-	if cacheable && t.cache != nil && d.Id != "" {
+	if t.cache != nil && d.Id != "" {
 		t.cache.put(d.Id, raw)
 	}
 	t.fromCache = false
@@ -317,8 +315,8 @@ func (t *websocketTransport) reader() {
 				// Compression is set up by the connect reply, which is the frame
 				// that carries the dictionary. A push may replace it later, which
 				// the protocol allows but the server does not currently do.
-				offered, cacheable := offeredDictionary(reply)
-				if c := t.dictionaryFrom(offered, cacheable); c != nil {
+				offered := offeredDictionary(reply)
+				if c := t.dictionaryFrom(offered); c != nil {
 					// Applied after this frame completes - see pendingCodec.
 					t.pendingCodec = c
 					// A dictionary that had to be sent is a real cost paid on this
@@ -356,18 +354,15 @@ func (t *websocketTransport) reader() {
 	}
 }
 
-// offeredDictionary returns the dictionary a reply carries, if any, and whether
-// it is worth caching past this connection. Unknown ConnectionState fields are
-// ignored on purpose: the message is meant to carry further connection-level
-// state in future without breaking older clients.
-func offeredDictionary(reply *protocol.Reply) (*protocol.Dictionary, bool) {
+// offeredDictionary returns the dictionary a reply carries, if any. Only the
+// connect reply carries one: there is no way to replace a dictionary
+// mid-connection, since the frame announcing a new one would have to be encoded
+// against the old.
+func offeredDictionary(reply *protocol.Reply) *protocol.Dictionary {
 	if reply.Connect != nil && reply.Connect.Dict != nil {
-		return reply.Connect.Dict, true
+		return reply.Connect.Dict
 	}
-	if reply.Push != nil && reply.Push.State != nil && reply.Push.State.Dict != nil {
-		return reply.Push.State.Dict, false
-	}
-	return nil, false
+	return nil
 }
 
 func (t *websocketTransport) Write(cmd *protocol.Command, timeout time.Duration) error {

--- a/transport_websocket.go
+++ b/transport_websocket.go
@@ -83,7 +83,7 @@ type websocketTransport struct {
 	unusableDict bool
 
 	// Compression accounting. Written by the reader goroutine, read by callers
-	// of Client.CompressionStats, hence atomics.
+	// of Client.DictionaryCompressionStats, hence atomics.
 	compressedIn   atomic.Int64
 	uncompressedIn atomic.Int64
 	dictionaryIn   atomic.Int64
@@ -94,12 +94,12 @@ type websocketTransport struct {
 }
 
 // compressionStats returns what this connection measured about compression.
-func (t *websocketTransport) compressionStats() CompressionStats {
+func (t *websocketTransport) dictionaryCompressionStats() DictionaryCompressionStats {
 	id := ""
 	if t.codec != nil {
 		id = t.codec.ID()
 	}
-	return CompressionStats{
+	return DictionaryCompressionStats{
 		Active:            t.codec != nil,
 		DictionaryID:      id,
 		Frames:            t.framesIn.Load(),

--- a/transport_websocket.go
+++ b/transport_websocket.go
@@ -254,23 +254,6 @@ func newWebsocketTransport(url string, protocolType protocol.Type, config websoc
 		protocolType:   protocolType,
 		cache:          cache,
 	}
-	// Install the codec for whatever this client is about to advertise, before
-	// the connect reply arrives. A server that recognises the id compresses the
-	// connect reply itself - there is nothing to wait for once both sides hold
-	// the dictionary - so learning the codec from a reply would mean never
-	// being able to read the reply that teaches it.
-	//
-	// Safe when the server does not recognise it: every frame carries a codec
-	// marker, so a raw reply passes through untouched and the dictionary it
-	// carries replaces this one.
-	if cache != nil {
-		if held := cache.advertise(); held != "" {
-			if bytes, ok := cache.get(held); ok {
-				t.codec = protocol.NewDeflateFrameCodec(held, bytes)
-				t.fromCache = true
-			}
-		}
-	}
 	go t.reader()
 	return t, nil
 }
@@ -344,15 +327,6 @@ func (t *websocketTransport) reader() {
 					if !t.fromCache {
 						t.dictionaryIn.Add(t.dictWireBytes)
 					}
-				} else if reply.Connect != nil &&
-					reply.Connect.Flag&connectionFlagDictionaryCompression == 0 {
-					// A codec installed from cache before connecting, on a
-					// connection the server then declined to compress. It marks
-					// this reply so it could be read, and nothing after it - so
-					// keeping the codec would mean stripping a marker off frames
-					// that do not have one.
-					t.codec = nil
-					t.pendingCodec = nil
 				} else if t.unusableDict {
 					// The server named a dictionary this client does not hold, so
 					// nothing after this frame can be decoded. Forget the id and

--- a/transport_websocket_test.go
+++ b/transport_websocket_test.go
@@ -2,10 +2,21 @@ package centrifuge
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
 	"testing"
 
 	"github.com/centrifugal/protocol"
 )
+
+// testDictionaryID is the derivation the protocol fixes for Dictionary.id:
+// SHA-256 of the content, first 12 bytes, base64url unpadded. This SDK never
+// computes one in earnest - its cache lives in memory, so there is nothing to
+// verify - but a test needs an id a server would actually have issued.
+func testDictionaryID(dict []byte) string {
+	sum := sha256.Sum256(dict)
+	return base64.RawURLEncoding.EncodeToString(sum[:12])
+}
 
 // A server that recognises the id a client advertised compresses the connect
 // reply itself, since both sides already hold the dictionary. The client must
@@ -19,7 +30,7 @@ import (
 // same way.
 func TestWebsocketTransport_DecodesCompressedConnectReply(t *testing.T) {
 	dict := []byte(`{"push":{"channel":"","pub":{"data":{"k":null}}}}`)
-	id := protocol.DictionaryID(dict)
+	id := testDictionaryID(dict)
 
 	cache := newDictionaryCache()
 	cache.put(id, dict)

--- a/transport_websocket_test.go
+++ b/transport_websocket_test.go
@@ -1,0 +1,57 @@
+package centrifuge
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/centrifugal/protocol"
+)
+
+// A server that recognises the id a client advertised compresses the connect
+// reply itself, since both sides already hold the dictionary. The client must
+// therefore be able to decode a frame before any reply has taught it a codec -
+// otherwise it can never read the reply that would.
+//
+// This regressed the moment the server started doing it: the codec was only
+// ever installed as a side effect of decoding a reply, which is circular when
+// the reply is the compressed thing. The symptom was a permanent disconnect
+// with a cached id that was never cleared, so every later attempt failed the
+// same way.
+func TestWebsocketTransport_DecodesCompressedConnectReply(t *testing.T) {
+	dict := []byte(`{"push":{"channel":"","pub":{"data":{"k":null}}}}`)
+	id := protocol.DictionaryID(dict)
+
+	cache := newDictionaryCache()
+	cache.put(id, dict)
+	if cache.advertise() != id {
+		t.Fatalf("cache must advertise the id it holds, got %q", cache.advertise())
+	}
+
+	tr := &websocketTransport{protocolType: protocol.TypeJSON, cache: cache}
+	// Mirrors what the constructor now does before the reader starts.
+	if held := cache.advertise(); held != "" {
+		if b, ok := cache.get(held); ok {
+			tr.codec = protocol.NewDeflateFrameCodec(held, b)
+			tr.fromCache = true
+		}
+	}
+	if tr.codec == nil {
+		t.Fatal("a client that advertises an id must be able to decode with it")
+	}
+
+	// A reply compressed against that dictionary, as a warm server sends it.
+	server := protocol.NewDeflateFrameCodec(id, dict)
+	raw := []byte(`{"id":1,"connect":{"client":"c1","dict":{"id":"` + id + `"}}}`)
+	onWire := server.Compress(nil, raw)
+	if onWire[0] != protocol.FrameCodecCompressed {
+		t.Fatal("this test is meaningless unless the frame really is compressed")
+	}
+
+	got, err := tr.codec.Decompress(nil, onWire, maxDecompressedFrameSize)
+	if err != nil {
+		t.Fatalf("a warm client must decode the compressed connect reply: %v", err)
+	}
+	if !bytes.Equal(raw, got) {
+		t.Fatalf("decoded frame differs:\n got %s\nwant %s", got, raw)
+	}
+}

--- a/transport_websocket_test.go
+++ b/transport_websocket_test.go
@@ -42,11 +42,12 @@ func TestWebsocketTransport_DecodesCompressedConnectReply(t *testing.T) {
 	// Mirrors what the constructor now does before the reader starts.
 	if held := cache.advertise(); held != "" {
 		if b, ok := cache.get(held); ok {
-			tr.codec = protocol.NewDeflateFrameCodec(held, b)
+			tr.codec.Store(protocol.NewDeflateFrameCodec(held, b))
 			tr.fromCache = true
 		}
 	}
-	if tr.codec == nil {
+	codec := tr.codec.Load()
+	if codec == nil {
 		t.Fatal("a client that advertises an id must be able to decode with it")
 	}
 
@@ -58,7 +59,7 @@ func TestWebsocketTransport_DecodesCompressedConnectReply(t *testing.T) {
 		t.Fatal("this test is meaningless unless the frame really is compressed")
 	}
 
-	got, err := tr.codec.Decompress(nil, onWire, maxDecompressedFrameSize)
+	got, err := codec.Decompress(nil, onWire, maxDecompressedFrameSize)
 	if err != nil {
 		t.Fatalf("a warm client must decode the compressed connect reply: %v", err)
 	}


### PR DESCRIPTION
Adds client support for connection-level dictionary compression.

A server that has one sends a shared DEFLATE dictionary in the connect reply, and compresses every later frame against it. This is what a client needs to decode those frames, advertise a dictionary it already holds, and report what the feature actually saved.

Requires the protocol change in centrifugal/protocol#39, pinned here until a tagged release.

## What a user has to do

Nothing, for decoding. Support is advertised automatically and the connection behaves exactly as before against a server that has no dictionary to offer.

One optional knob:

```go
centrifuge.Config{
    // Names the kind of client this is, so a server can serve a dictionary
    // built for connections of that shape.
    Profile: "trading-dashboard",
}
```

`Profile` describes the client, not the user — a small fixed set of names, like `Name`. The server may ignore or override it, so it must never gate anything.

## Reporting

`Client.DictionaryCompressionStats()` returns what the connection measured:

```go
s := client.DictionaryCompressionStats()
s.Active            // decoding compressed frames right now
s.Frames            // compressed frames received
s.BytesReceived     // what they cost on the wire
s.BytesDecompressed // what they expanded to
s.DictionaryID      // which dictionary is in use
s.DictionaryBytes   // what the dictionary itself cost to receive
s.BytesSaved()      // net, after subtracting the dictionary transfer
s.Ratio()           // uncompressed over compressed, ignoring the transfer
```

`BytesSaved()` subtracts the dictionary transfer deliberately and **can be negative** on a connection that received too little traffic to earn it back — that is the honest number for deciding whether the feature is worth it. `Ratio()` ignores the transfer, so the two answer different questions.

Two caveats are in the doc comment as well, because the numbers flatter the feature otherwise: they compare against sending frames uncompressed rather than against `permessage-deflate`, and they are measured on WebSocket payloads so they exclude framing.

## How it works

- **The dictionary arrives in the connect reply.** That reply is the last uncompressed frame, so there is no window in which a compressed frame can arrive before the dictionary that decodes it, and no negotiation to race.
- **Frames are self-describing.** Each carries a one-byte marker saying whether it was compressed, so a server can decline any individual frame and the client does not have to remember what was negotiated.
- **The dictionary is cached in memory and re-advertised on reconnect.** The server then sends only an id, and nothing is transferred. Cached in memory rather than on disk: an id identifies content, so the cache can never return bytes for the wrong dictionary, and there is nothing on disk for anything else to rewrite.
- **A dictionary the server declines is dropped.** If the server names an id this client does not hold, or a frame fails to decode, the entry is forgotten so the next connect does not advertise it again and wedge the client in a loop.

## Notes for review

- `transport_websocket.go` carries most of it: the codec install, the one-frame-late activation, and the byte accounting.
- The dictionary id derivation is not imported from `protocol` — it is stated on `Dictionary.id` in the protocol definition and each implementation carries its own copy. This SDK only needs it in a test, since its cache is in memory and has nothing to verify.
- `go.mod` pins `protocol` to the merged commit rather than a tag. That has to become a tagged version before release.
