### PR TITLE
Bump github.com/centrifugal/protocol to v0.21.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/centrifugal/centrifuge-go
 go 1.25.0
 
 require (
-	github.com/centrifugal/protocol v0.19.2
+	github.com/centrifugal/protocol v0.21.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/jpillora/backoff v1.0.0
 	github.com/shadowspore/fossil-delta v0.0.0-20241213113458-1d797d70cbe3

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/centrifugal/protocol v0.19.2 h1:wc1S75EJvX5/KczsqEG74Bt/Jw/XwECDUzWR/vE/E9U=
-github.com/centrifugal/protocol v0.19.2/go.mod h1:zFsp4f1ZRejq1dkyNUbabdPj4dMYOpK8RRXDwHGVpVY=
+github.com/centrifugal/protocol v0.21.0 h1:yagnxWBH7vK2+0+A0bmPAIOCaFqTvaLVWubkklS7Xyo=
+github.com/centrifugal/protocol v0.21.0/go.mod h1:3pinAfcb+bH8Yp8Ewhf9QTRTzsQ9veP/QOrCk5D5SSE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=


### PR DESCRIPTION
## Summary

Bumps `github.com/centrifugal/protocol` from `v0.19.2` to **v0.21.0**.

`v0.19.2` pinned the vulnerable `ProtobufReplyDecoder`, which reads a length-prefix varint and slices the buffer **without a bounds check**. A malformed `Reply` frame from a malicious or compromised server therefore panics the decoder, and since the reader runs in a bare, unrecovered goroutine, this crashes the entire embedding application. See [GHSA-98cg-m2cg-6xpr](https://github.com/centrifugal/centrifugo/security/advisories/GHSA-98cg-m2cg-6xpr).

The bounds check was added upstream in `v0.20.0`; `v0.21.0` includes it.

## No code changes

This SDK uses only the reply decoder's unchanged public API, so the fix is a pure dependency bump. Builds and `go vet` clean.