### PR TITLE
Fix race that could invoke request callbacks twice

### DIFF
--- a/client.go
+++ b/client.go
@@ -852,15 +852,10 @@ func (c *Client) handle(reply *protocol.Reply) {
 		if c.logLevelEnabled(LogLevelTrace) {
 			c.traceInReply(reply)
 		}
-		c.requestsMu.RLock()
-		req, ok := c.requests[reply.Id]
-		c.requestsMu.RUnlock()
-		if ok {
-			if req.cb != nil {
-				req.cb(reply, nil)
-			}
+		req, ok := c.popRequest(reply.Id)
+		if ok && req.cb != nil {
+			req.cb(reply, nil)
 		}
-		c.removeRequest(reply.Id)
 	} else {
 		if reply.Push == nil {
 			if c.logLevelEnabled(LogLevelTrace) {
@@ -2160,20 +2155,15 @@ func (c *Client) sendAsync(cmd *protocol.Command, cb func(*protocol.Reply, error
 		c.mu.Lock()
 		closeCh := c.closeCh
 		c.mu.Unlock()
-		defer c.removeRequest(cmd.Id)
 		select {
 		case <-time.After(c.config.ReadTimeout):
-			c.requestsMu.RLock()
-			req, ok := c.requests[cmd.Id]
-			c.requestsMu.RUnlock()
+			req, ok := c.popRequest(cmd.Id)
 			if !ok {
 				return
 			}
 			req.cb(nil, ErrTimeout)
 		case <-closeCh:
-			c.requestsMu.RLock()
-			req, ok := c.requests[cmd.Id]
-			c.requestsMu.RUnlock()
+			req, ok := c.popRequest(cmd.Id)
 			if !ok {
 				return
 			}
@@ -2213,6 +2203,19 @@ func (c *Client) removeRequest(id uint32) {
 	c.requestsMu.Lock()
 	defer c.requestsMu.Unlock()
 	delete(c.requests, id)
+}
+
+// popRequest atomically looks up and removes the request with the given id,
+// so that only one caller (the actual reply, a timeout, or a close) can ever
+// observe it and invoke its callback.
+func (c *Client) popRequest(id uint32) (request, bool) {
+	c.requestsMu.Lock()
+	defer c.requestsMu.Unlock()
+	req, ok := c.requests[id]
+	if ok {
+		delete(c.requests, id)
+	}
+	return req, ok
 }
 
 type disconnect struct {

--- a/client_test.go
+++ b/client_test.go
@@ -5,12 +5,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"math/rand"
 	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/centrifugal/protocol"
 )
 
 type testEventHandler struct {
@@ -988,5 +991,65 @@ func TestLogLevel(t *testing.T) {
 				t.Errorf("expected %v got %v", tc.enabled, got)
 			}
 		})
+	}
+}
+
+// noopTransport is a transport whose Write always succeeds without actually
+// sending anything anywhere, so sendAsync's ReadTimeout goroutine gets
+// started without needing a real connection.
+type noopTransport struct{}
+
+func (noopTransport) Read() (*protocol.Reply, *disconnect, error)  { return nil, nil, io.EOF }
+func (noopTransport) Write(*protocol.Command, time.Duration) error { return nil }
+func (noopTransport) Close() error                                 { return nil }
+
+// TestClient_RequestCallbackNotInvokedTwiceOnTimeoutRace is a regression test
+// for a race where a reply arriving at almost the same moment its ReadTimeout
+// fired could invoke the same request's callback twice: once from handle()
+// with the real reply, once from the sendAsync timeout goroutine with
+// ErrTimeout. Since callers resolve via a buffered channel of size 1, the
+// second invocation used to block forever, leaking a goroutine.
+//
+// The callback below sleeps briefly after being invoked to widen the window
+// between "request found pending" and "request removed from the map" -
+// before the fix that window spanned the callback's own execution, so any
+// concurrent racer would still find the request present and invoke it too.
+// With the fix, the request is popped from the map atomically before its
+// callback runs, so a concurrent racer always finds it already gone.
+func TestClient_RequestCallbackNotInvokedTwiceOnTimeoutRace(t *testing.T) {
+	config := Config{ReadTimeout: time.Microsecond}
+	c := NewJsonClient("ws://localhost:9000/connection/websocket", config)
+	c.transport = noopTransport{}
+	c.closeCh = make(chan struct{})
+
+	const iterations = 20
+	for i := 0; i < iterations; i++ {
+		cmd := &protocol.Command{Id: uint32(i + 1)}
+		var calls int32
+		done := make(chan struct{}, 2)
+		cb := func(reply *protocol.Reply, err error) {
+			atomic.AddInt32(&calls, 1)
+			time.Sleep(20 * time.Millisecond)
+			done <- struct{}{}
+		}
+
+		if err := c.sendAsync(cmd, cb); err != nil {
+			t.Fatalf("sendAsync: %v", err)
+		}
+		// Deliver the real reply concurrently with the sendAsync-spawned
+		// ReadTimeout goroutine, which fires almost immediately given the
+		// tiny ReadTimeout configured above.
+		c.handle(&protocol.Reply{Id: cmd.Id})
+
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatalf("request %d: callback was never invoked", cmd.Id)
+		}
+		// Give the loser of the race a chance to (incorrectly) also fire.
+		time.Sleep(30 * time.Millisecond)
+		if got := atomic.LoadInt32(&calls); got != 1 {
+			t.Fatalf("request %d: callback invoked %d times, want 1", cmd.Id, got)
+		}
 	}
 }


### PR DESCRIPTION
## What changed

`Client.handle()` looked up a pending request, invoked its callback, and only afterwards removed it from the `requests` map — three separate steps, each taking `requestsMu` independently. The timeout/close goroutine spawned by `sendAsync()` did the same check-then-act sequence on its own.

If a reply arrived at nearly the same moment its `ReadTimeout` fired (or the client closed), both goroutines could observe the request as still present and each invoke its callback — so a single `RPC`/`Publish`/`History`/`Presence`/`PresenceStats` call could complete twice: once with the real reply, once with a spurious `ErrTimeout` or `ErrClientDisconnected`.

Since these exported methods resolve via a buffered channel of size 1, the second invocation could then block forever trying to send into an already-drained channel, leaking a goroutine.

Added `Client.popRequest`, which looks up and deletes the request entry under a single lock, so only one caller can ever win the race and invoke the callback. `handle()` and `sendAsync()` now use it in place of their separate read/callback/remove steps.

No exported API changes.

## Why

This is a real, if narrow, race window in existing concurrent code — worth closing since it can silently double-fire user callbacks or leak a goroutine.

## How verified

- `go build ./...` and `go vet ./...`
- Started the repo's `docker-compose.yml` Centrifugo test server and ran `go test ./... -race -count=1` — all tests pass.