### PR TITLE
Fix deadlock risk in subscription refresh error handling

### DIFF
--- a/subscription.go
+++ b/subscription.go
@@ -1032,9 +1032,9 @@ func (s *Subscription) scheduleSubRefresh(ttl uint32) {
 				s.unsubscribe(unsubscribedUnauthorized, "unauthorized", true)
 				return
 			}
+			s.emitError(SubscriptionRefreshError{Err: err})
 			s.mu.Lock()
 			defer s.mu.Unlock()
-			s.emitError(SubscriptionRefreshError{Err: err})
 			s.scheduleSubRefresh(10)
 			return
 		}

--- a/subscription_refresh_test.go
+++ b/subscription_refresh_test.go
@@ -1,0 +1,60 @@
+package centrifuge
+
+// Regression test for a deadlock in the subscription refresh error path: on a
+// GetToken failure during sub refresh, emitError (which synchronously waits for
+// the OnError handler to run on the client's callback-dispatch goroutine) was
+// called while holding s.mu. If the OnError handler touched the Subscription's
+// own lock (e.g. calling State()), the dispatch goroutine would block on s.mu
+// forever while the goroutine holding s.mu waited on the dispatch goroutine —
+// a classic deadlock that would also freeze the shared callback queue for the
+// whole client. See subscription.go scheduleSubRefresh.
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/centrifugal/protocol"
+)
+
+func TestSubRefreshErrorHandlerDoesNotDeadlock(t *testing.T) {
+	server := NewFakeServer(t)
+	server.OnSubscribe = func(_ string, _ *protocol.SubscribeRequest) *protocol.SubscribeResult {
+		return &protocol.SubscribeResult{Expires: true, Ttl: 1}
+	}
+
+	client := NewProtobufClient(server.URL(), Config{})
+	t.Cleanup(client.Close)
+
+	var tokenCalls int32
+	sub, err := client.NewSubscription("ch", SubscriptionConfig{
+		GetToken: func(_ SubscriptionTokenEvent) (string, error) {
+			if atomic.AddInt32(&tokenCalls, 1) == 1 {
+				return "initial-token", nil
+			}
+			return "", errors.New("boom")
+		},
+	})
+	if err != nil {
+		t.Fatalf("new subscription: %v", err)
+	}
+
+	subscribedCh := make(chan SubscribedEvent, 4)
+	errCh := make(chan SubscriptionErrorEvent, 4)
+	sub.OnSubscribed(func(e SubscribedEvent) { subscribedCh <- e })
+	sub.OnError(func(e SubscriptionErrorEvent) {
+		// Touching the Subscription's own lock from within the handler must
+		// not deadlock even if the handler ran while emitError's caller held
+		// s.mu.
+		_ = sub.State()
+		errCh <- e
+	})
+
+	_ = client.Connect()
+	_ = sub.Subscribe()
+	waitCh(t, subscribedCh, "subscribed")
+
+	// Ttl=1s triggers a refresh, which fails GetToken (second call) and must
+	// reach the OnError handler without hanging.
+	waitCh(t, errCh, "refresh error")
+}


### PR DESCRIPTION
## What changed

In `subscription.go`, `scheduleSubRefresh`'s GetToken-error branch held `s.mu` while calling `s.emitError(...)`. `emitError` calls `runHandlerSync`, which pushes the user's `OnError` callback onto the client's shared callback-dispatch queue and blocks the calling goroutine until that callback finishes running on the dispatch goroutine.

If the `OnError` handler touches the `Subscription`'s own lock — e.g. calls `sub.State()` or `sub.Unsubscribe()`, both of which take `s.mu` — the dispatch goroutine blocks trying to acquire `s.mu`, while the goroutine that already holds `s.mu` is itself blocked waiting for the dispatch goroutine to finish. That's a deadlock, and since the callback queue is shared per-client, it freezes event delivery for the entire client, not just this subscription.

Every other `emitError` call site in the file releases `s.mu` before calling it — including the near-identical branch six lines below this one (the `sendSubRefresh` reply error handler). This change aligns the GetToken-error branch with that established pattern: call `emitError` before acquiring the lock, then lock only for `scheduleSubRefresh(10)`.

## Why

Small, local, no API change — moves one `emitError` call outside a lock scope to match the pattern used everywhere else in the file.

## Test plan

Added `TestSubRefreshErrorHandlerDoesNotDeadlock` in `subscription_refresh_test.go`. It uses the in-process `FakeServer` to negotiate a subscription with a 1-second TTL, fails the second `GetToken` call (the refresh call), and registers an `OnError` handler that calls `sub.State()` — reproducing the lock re-entry from within the callback.

- Against the pre-fix code, this test reliably deadlocks: Go's runtime deadlock detector reports it directly (`goroutine ... [sync.RWMutex.RLock]` blocked in `Subscription.State`, waiting on the callback-dispatch goroutine which itself waits on `s.mu`).
- Against the fix, it passes in ~1s.

Kept the test in the tree — it guards a real deadlock class specific to this codebase's synchronous callback dispatch, isn't redundant with existing coverage, and isn't tied to fragile internals.

Also ran the full suite (`go build ./...`, `go vet ./...`, `go test ./...`) against a local `docker-compose` Centrifugo, and `golangci-lint run ./...` (0 issues) — all pass.