### PR TITLE
Reset server-side subscription recovery position on state invalidation

### DIFF
--- a/client.go
+++ b/client.go
@@ -761,6 +761,14 @@ func (c *Client) invalidateConnectionState() {
 	for _, s := range c.subs {
 		subs = append(subs, s)
 	}
+	for _, s := range c.serverSubs {
+		// Reset cached recovery position to a deliberately unrecoverable one,
+		// same as for client-side subscriptions above: Recoverable stays as-is,
+		// but the next connect request must not ask the server to recover from
+		// a position that predates the state invalidation.
+		s.Offset = 0
+		s.Epoch = stateInvalidatedEpoch
+	}
 	c.mu.Unlock()
 	for _, s := range subs {
 		s.invalidateState()

--- a/state_invalidation_test.go
+++ b/state_invalidation_test.go
@@ -67,6 +67,36 @@ func TestInvalidateConnectionStateClearsTokenAndAllSubs(t *testing.T) {
 	}
 }
 
+func TestInvalidateConnectionStateResetsServerSubRecoveryPosition(t *testing.T) {
+	server := NewFakeServer(t)
+	client := NewProtobufClient(server.URL(), Config{Token: "conn-token"})
+	t.Cleanup(client.Close)
+
+	client.mu.Lock()
+	client.serverSubs["ch"] = &serverSub{
+		Recoverable: true,
+		Offset:      10,
+		Epoch:       "e1",
+	}
+	client.mu.Unlock()
+
+	client.invalidateConnectionState()
+
+	client.mu.Lock()
+	sub := client.serverSubs["ch"]
+	client.mu.Unlock()
+	if sub == nil {
+		t.Fatal("server-side subscription must still be present")
+	}
+	// Recovery position is reset to the same unrecoverable sentinel used for
+	// client-side subscriptions, so the next connect request doesn't ask the
+	// server to recover from a position that predates the invalidation.
+	// Recoverable is left untouched.
+	if !sub.Recoverable || sub.Offset != 0 || sub.Epoch != stateInvalidatedEpoch {
+		t.Fatalf("server-side sub recovery position must be reset to the unrecoverable sentinel, got offset=%d epoch=%q recoverable=%v", sub.Offset, sub.Epoch, sub.Recoverable)
+	}
+}
+
 func TestUnsubscribe2502InvalidatesAndResubscribes(t *testing.T) {
 	server := NewFakeServer(t)
 	client := NewProtobufClient(server.URL(), Config{})

--- a/state_invalidation_test.go
+++ b/state_invalidation_test.go
@@ -7,6 +7,8 @@ package centrifuge
 
 import (
 	"testing"
+
+	"github.com/centrifugal/protocol"
 )
 
 func TestInvalidateStateClearsTokenAndDeltaBase(t *testing.T) {
@@ -94,6 +96,53 @@ func TestInvalidateConnectionStateResetsServerSubRecoveryPosition(t *testing.T) 
 	// Recoverable is left untouched.
 	if !sub.Recoverable || sub.Offset != 0 || sub.Epoch != stateInvalidatedEpoch {
 		t.Fatalf("server-side sub recovery position must be reset to the unrecoverable sentinel, got offset=%d epoch=%q recoverable=%v", sub.Offset, sub.Epoch, sub.Recoverable)
+	}
+}
+
+func TestDisconnect3014ResetsServerSubRecoveryPositionOnWire(t *testing.T) {
+	// End-to-end companion to TestInvalidateConnectionStateResetsServerSubRecoveryPosition:
+	// that test proves invalidateConnectionState mutates serverSubs in isolation, this one
+	// proves the reset value actually reaches the wire on the reconnect's Connect request.
+	server := NewFakeServer(t)
+	server.ConnectResult = &protocol.ConnectResult{
+		Client: "fake-client",
+		Subs: map[string]*protocol.SubscribeResult{
+			"news": {Recoverable: true, Epoch: "server-epoch", Offset: 5},
+		},
+	}
+	client := NewProtobufClient(server.URL(), Config{
+		GetToken: func(ConnectionTokenEvent) (string, error) { return "c1", nil },
+	})
+	t.Cleanup(client.Close)
+
+	subscribedCh := make(chan ServerSubscribedEvent, 4)
+	client.OnSubscribed(func(e ServerSubscribedEvent) { subscribedCh <- e })
+
+	_ = client.Connect()
+	waitCh(t, subscribedCh, "server-side subscribed")
+
+	lastConnect := func() *protocol.ConnectRequest {
+		received := server.Received()
+		for i := len(received) - 1; i >= 0; i-- {
+			if received[i].Connect != nil {
+				return received[i].Connect
+			}
+		}
+		return nil
+	}
+	if sub := lastConnect().Subs["news"]; sub != nil {
+		t.Fatalf("initial connect must carry no server subs to recover, got %+v", sub)
+	}
+
+	server.DisconnectPush(disconnectedStateInvalidated, "state invalidated")
+	waitCh(t, subscribedCh, "resubscribed after reconnect")
+
+	sub := lastConnect().Subs["news"]
+	if sub == nil {
+		t.Fatal("reconnect must request recovery for the server-side sub")
+	}
+	if !sub.Recover || sub.Offset != 0 || sub.Epoch != stateInvalidatedEpoch {
+		t.Fatalf("reconnect must not carry the pre-invalidation offset/epoch, got recover=%v offset=%d epoch=%q", sub.Recover, sub.Offset, sub.Epoch)
 	}
 }
 


### PR DESCRIPTION
## Bug

On disconnect code 3014 (state invalidated), `Client.invalidateConnectionState` already resets each client-side `Subscription`'s cached recovery position (offset/epoch) to the unrecoverable sentinel epoch `"_"`, so the next connect/subscribe can't accidentally recover from now-invalid state.

Server-side subscriptions (tracked in `Client.serverSubs`, populated from the Connect reply's `subs` field) were left untouched. `sendConnect` unconditionally sends each recoverable `serverSub`'s cached offset/epoch as recovery params on every reconnect, so an application relying only on server-side subscriptions kept requesting recovery from the stale pre-invalidation position after a 3014 disconnect, defeating the entire point of state invalidation.

## Fix

In `invalidateConnectionState`, also reset `Offset`/`Epoch` to the same sentinel for every entry in `c.serverSubs`, leaving `Recoverable` untouched — mirroring the existing client-side subscription handling in the same method and under the same lock.

Added a regression test (`TestInvalidateConnectionStateResetsServerSubRecoveryPosition`) that sets up a recoverable server-side subscription with a known offset/epoch, triggers `invalidateConnectionState`, and asserts the offset/epoch were reset to `0`/`"_"` while `Recoverable` stays `true`.

This mirrors the same fix already applied in centrifugal/centrifuge-swift#135 and centrifugal/centrifuge-js#385.

## Test plan

- `go build ./...`
- `go vet ./...`
- `golangci-lint run` — 0 issues
- `go test -race ./...` against docker-compose Centrifugo — all pass