### PR TITLE
Report subscription refresh failures as SubscriptionRefreshError

### DIFF
--- a/subscription.go
+++ b/subscription.go
@@ -1045,7 +1045,7 @@ func (s *Subscription) scheduleSubRefresh(ttl uint32) {
 
 		s.centrifuge.sendSubRefresh(s.Channel, token, func(result *protocol.SubRefreshResult, err error) {
 			if err != nil {
-				s.emitError(SubscriptionSubscribeError{Err: err})
+				s.emitError(SubscriptionRefreshError{Err: err})
 				var serverError *Error
 				if errors.As(err, &serverError) {
 					if serverError.Temporary {

--- a/subscription_refresh_test.go
+++ b/subscription_refresh_test.go
@@ -58,3 +58,61 @@ func TestSubRefreshErrorHandlerDoesNotDeadlock(t *testing.T) {
 	// reach the OnError handler without hanging.
 	waitCh(t, errCh, "refresh error")
 }
+
+// Regression test for sub refresh failures being reported as
+// SubscriptionSubscribeError: a failed sub_refresh command must surface as
+// SubscriptionRefreshError so apps can tell "my subscription token could not be
+// renewed" apart from "subscribing failed". The GetToken failure path in the
+// same flow already emitted SubscriptionRefreshError, and the connection-level
+// counterpart (Client.sendRefresh) consistently emits RefreshError.
+func TestSubRefreshErrorEmitsRefreshError(t *testing.T) {
+	server := NewFakeServer(t)
+	server.OnSubscribe = func(_ string, _ *protocol.SubscribeRequest) *protocol.SubscribeResult {
+		return &protocol.SubscribeResult{Expires: true, Ttl: 1}
+	}
+	// Fail the sub_refresh command with a temporary server error: the
+	// subscription stays subscribed and the SDK retries, but the app must be
+	// told about the refresh failure.
+	server.OnCommand = func(cmd *protocol.Command) *protocol.Reply {
+		if cmd.SubRefresh == nil {
+			return nil
+		}
+		return &protocol.Reply{Id: cmd.Id, Error: &protocol.Error{
+			Code: 108, Message: "not available", Temporary: true,
+		}}
+	}
+
+	client := NewProtobufClient(server.URL(), Config{})
+	t.Cleanup(client.Close)
+
+	sub, err := client.NewSubscription("ch", SubscriptionConfig{
+		GetToken: func(_ SubscriptionTokenEvent) (string, error) {
+			return "token", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("new subscription: %v", err)
+	}
+
+	subscribedCh := make(chan SubscribedEvent, 4)
+	errCh := make(chan SubscriptionErrorEvent, 4)
+	sub.OnSubscribed(func(e SubscribedEvent) { subscribedCh <- e })
+	sub.OnError(func(e SubscriptionErrorEvent) { errCh <- e })
+
+	_ = client.Connect()
+	_ = sub.Subscribe()
+	waitCh(t, subscribedCh, "subscribed")
+
+	ev := waitCh(t, errCh, "refresh error")
+	var refreshErr SubscriptionRefreshError
+	if !errors.As(ev.Error, &refreshErr) {
+		t.Fatalf("expected SubscriptionRefreshError, got %T: %v", ev.Error, ev.Error)
+	}
+	var serverErr *Error
+	if !errors.As(ev.Error, &serverErr) || serverErr.Code != 108 {
+		t.Fatalf("expected wrapped server error with code 108, got %v", ev.Error)
+	}
+	if state := sub.State(); state != SubStateSubscribed {
+		t.Fatalf("expected subscription to stay subscribed after temporary refresh error, got %s", state)
+	}
+}


### PR DESCRIPTION
## What

A failed `sub_refresh` command emitted `SubscriptionSubscribeError` to the subscription's `OnError` handler instead of `SubscriptionRefreshError`.

## Why

This is a one-word inconsistency with real consequences for apps that branch on the error type in `OnError`: a subscription token that could not be renewed was indistinguishable from a subscribe failure.

The intended semantics are clear from the surrounding code:

- The `GetToken` failure path in the *same* `scheduleSubRefresh` flow already emits `SubscriptionRefreshError` (`subscription.go:1035`).
- The connection-level counterpart, `Client.sendRefresh`, consistently emits `RefreshError` in every one of its failure branches.
- `centrifuge-js` emits error type `'refresh'` (not `'subscribe'`) from its `Subscription._refreshError`.

`SubscriptionRefreshError` is already exported and already wraps the underlying error via `Unwrap`, so `errors.As`/`errors.Is` against the server `*Error` keeps working exactly as before. No API change.

## Validating test

Added `TestSubRefreshErrorEmitsRefreshError` in `subscription_refresh_test.go`, using the existing in-process `FakeServer` (no Centrifugo needed). It subscribes with `Expires: true, Ttl: 1`, then fails the resulting `sub_refresh` command with a temporary server error (code 108), and asserts that the emitted `SubscriptionErrorEvent`:

- unwraps to `SubscriptionRefreshError`,
- still unwraps to the server `*Error` with code 108,
- leaves the subscription in `SubStateSubscribed` (temporary error ⇒ SDK retries rather than unsubscribing).

Against the old code it fails with:

```
expected SubscriptionRefreshError, got centrifuge.SubscriptionSubscribeError: subscribe error: 108: not available
```

It is kept in the tree: it guards a user-visible error-classification contract, is cheap and deterministic, and sits next to the existing sub-refresh regression test without duplicating it (that one covers a deadlock in the `GetToken` failure path).

## Verification

`go vet ./...`, `gofmt -l .` clean, and the full package suite run with `-race` against the repository's own `docker compose` Centrifugo: `ok github.com/centrifugal/centrifuge-go 15.166s`.